### PR TITLE
Use distroless static base images for containers

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,0 +1,1 @@
+defaultBaseImage: gcr.io/distroless/static-debian13:latest


### PR DESCRIPTION
The ko build default of chainguard runs as a non-root user. This messes with our haproxy certificates
host volume mount.

Switching to distroless static base images running as root inside the container.