### PR TITLE
Fix version tag reading

### DIFF
--- a/cmd/certificatee/main.go
+++ b/cmd/certificatee/main.go
@@ -18,6 +18,11 @@ import (
 	"github.com/vinted/certificator/pkg/vault"
 )
 
+var (
+	version = "dev"  // GoReleaser will inject the Git tag here
+	commit  = "none" // GoReleaser will inject the SHA here
+)
+
 func main() {
 	cfg, err := config.LoadConfig()
 	if err != nil {
@@ -39,8 +44,8 @@ func main() {
 	ticker := time.NewTicker(cfg.Certificatee.UpdateInterval)
 	defer ticker.Stop()
 
-	certmetrics.Up.WithLabelValues("certificator", cfg.Version, cfg.Hostname, cfg.Environment).Set(1)
-	defer certmetrics.Up.WithLabelValues("certificator", cfg.Version, cfg.Hostname, cfg.Environment).Set(0)
+	certmetrics.Up.WithLabelValues("certificator", version, cfg.Hostname, cfg.Environment).Set(1)
+	defer certmetrics.Up.WithLabelValues("certificator", version, cfg.Hostname, cfg.Environment).Set(0)
 
 	// Initial run
 	if err := maybeUpdateCertificates(logger, cfg, vaultClient); err != nil {

--- a/cmd/certificator/main.go
+++ b/cmd/certificator/main.go
@@ -11,6 +11,11 @@ import (
 	"github.com/vinted/certificator/pkg/vault"
 )
 
+var (
+	version = "dev"  // GoReleaser will inject the Git tag here
+	commit  = "none" // GoReleaser will inject the SHA here
+)
+
 func main() {
 	cfg, err := config.LoadConfig()
 	if err != nil {
@@ -35,8 +40,8 @@ func main() {
 		logger.Fatal(err)
 	}
 
-	certmetrics.Up.WithLabelValues("certificator", cfg.Version, cfg.Hostname, cfg.Environment).Set(1)
-	defer certmetrics.Up.WithLabelValues("certificator", cfg.Version, cfg.Hostname, cfg.Environment).Set(0)
+	certmetrics.Up.WithLabelValues("certificator", version, cfg.Hostname, cfg.Environment).Set(1)
+	defer certmetrics.Up.WithLabelValues("certificator", version, cfg.Hostname, cfg.Environment).Set(0)
 
 	var failedDomains []string
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"os"
-	"runtime/debug"
 	"strings"
 	"time"
 
@@ -42,7 +41,6 @@ type Metrics struct {
 
 // Config contains all configuration parameters
 type Config struct {
-	Version         string
 	Hostname        string
 	Acme            Acme
 	Vault           Vault
@@ -64,24 +62,12 @@ type Certificatee struct {
 
 // LoadConfig loads configuration options to  variable
 func LoadConfig() (Config, error) {
-	// Get version from runtime build info
-	version := "unknown"
-	if bi, ok := debug.ReadBuildInfo(); ok {
-		for _, s := range bi.Settings {
-			if s.Key == "vcs.revision" {
-				version = s.Value
-				break
-			}
-		}
-	}
-
 	hostname, err := os.Hostname()
 	if err != nil {
 		hostname = "unknown"
 	}
 
 	cfg := Config{
-		Version:  version,
 		Hostname: hostname,
 		Log: Log{
 			Logger: logrus.New(),


### PR DESCRIPTION
Read version from injected variables instead of
build info. We get the git tag this way.