### PR TITLE
Add certificates_checked_total metric

### DIFF
--- a/cmd/certificator/main.go
+++ b/cmd/certificator/main.go
@@ -69,12 +69,15 @@ func main() {
 			if err != nil {
 				failedDomains = append(failedDomains, mainDomain)
 				certmetrics.CertificatesRenewalFailures.WithLabelValues(mainDomain).Inc()
+				certmetrics.CertificatesChecked.WithLabelValues(mainDomain, "failure").Inc()
 				logger.Error(err)
 				continue
 			}
 			certmetrics.CertificatesRenewed.WithLabelValues(mainDomain).Inc()
+			certmetrics.CertificatesChecked.WithLabelValues(mainDomain, "renewed").Inc()
 			logger.Infof("certificate for %s renewed successfully", mainDomain)
 		} else {
+			certmetrics.CertificatesChecked.WithLabelValues(mainDomain, "valid").Inc()
 			logger.Infof("certificate for %s is up to date, skipping renewal", mainDomain)
 		}
 	}

--- a/pkg/certmetrics/metrics.go
+++ b/pkg/certmetrics/metrics.go
@@ -28,6 +28,10 @@ var (
 		Name: "certificator_certificates_renewal_failures_total",
 		Help: "Total number of certificate renewal failures",
 	}, []string{"domain"})
+	CertificatesChecked = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "certificator_certificates_checked_total",
+		Help: "Total number of certificates checked",
+	}, []string{"domain", "status"})
 
 	// Certificatee metrics - certificate updates and expiry
 	CertificatesUpdated = promauto.NewCounterVec(prometheus.CounterOpts{


### PR DESCRIPTION
## Summary
- Add `certificator_certificates_checked_total{domain, status}` counter metric
- Status labels: `valid` (no renewal needed), `renewed` (successfully renewed), `failure` (renewal failed)
- Ensures every batch run produces metrics regardless of whether renewals occur

## Test plan
- [ ] Deploy to staging and trigger batch job
- [ ] Verify `certificator_certificates_checked_total` appears in VictoriaMetrics
- [ ] Confirm status label values are correct for each domain