### PR TITLE
Fix wildcard cert handling + stale cert detection via TLS serial comparison

### DIFF
--- a/cmd/certificatee/main.go
+++ b/cmd/certificatee/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	legoLog "github.com/go-acme/lego/v4/log"
@@ -100,7 +101,15 @@ func processHAProxyEndpoint(logger *logrus.Logger, cfg config.Config, vaultClien
 	certmetrics.LastSyncTimestamp.WithLabelValues(endpoint).SetToCurrentTime()
 	certmetrics.CertificatesTotal.WithLabelValues(endpoint).Set(float64(len(certRefs)))
 
-	logger.Infof("[%s] %d certificates found", endpoint, len(certRefs))
+	var wildcardCount int
+	for _, ref := range certRefs {
+		if strings.Contains(ref.DisplayName, "*") || strings.Contains(ref.FilePath, "*") {
+			wildcardCount++
+		}
+	}
+	certmetrics.CertificatesWildcard.WithLabelValues(endpoint).Set(float64(wildcardCount))
+
+	logger.Infof("[%s] %d certificates found (%d with wildcard names)", endpoint, len(certRefs), wildcardCount)
 
 	var errs []error
 	var expiringCount int
@@ -109,8 +118,9 @@ func processHAProxyEndpoint(logger *logrus.Logger, cfg config.Config, vaultClien
 		certPath := ref.DisplayName
 		logger.Infof("[%s] Checking certificate: %s", endpoint, certPath)
 
-		// Extract domain name from certificate path
-		domain := haproxy.ExtractDomainFromPath(certPath)
+		// Extract domain name from certificate path and normalize _.domain → *.domain for Vault
+		rawDomain := haproxy.ExtractDomainFromPath(certPath)
+		domain := haproxy.NormalizeDomainForVault(rawDomain)
 		logger.Debugf("[%s] Extracted domain '%s' from path '%s'", endpoint, domain, certPath)
 
 		// Check if certificate needs update (uses Vault as source of truth for cert details,
@@ -120,6 +130,16 @@ func processHAProxyEndpoint(logger *logrus.Logger, cfg config.Config, vaultClien
 			errs = append(errs, err)
 			logger.Errorf("[%s] %v", endpoint, err)
 			continue
+		}
+
+		// Serial mismatch check: if Vault cert is not expiring but HAProxy is serving an older
+		// cert (e.g. cert was renewed but push failed, or HAProxy has expired cert post-renewal),
+		// detect it by comparing serial numbers via a live TLS dial.
+		if !shouldUpdate {
+			if serialUpdate, serialReason := checkSerialMismatch(domain, vaultClient, haproxyClient, logger); serialUpdate {
+				shouldUpdate = true
+				reason = serialReason
+			}
 		}
 
 		// Track expiring certificates
@@ -218,6 +238,30 @@ func buildPEMBundle(secrets map[string]any) (string, error) {
 	}
 
 	return pemData, nil
+}
+
+// checkSerialMismatch detects when HAProxy is serving a different cert than what's in Vault.
+// This catches cases where Vault has a freshly renewed cert but HAProxy still serves the old one.
+func checkSerialMismatch(domain string, vaultClient *vault.VaultClient, haproxyClient *haproxy.Client, logger *logrus.Logger) (bool, string) {
+	vaultCert, err := certificate.GetCertificate(domain, vaultClient)
+	if err != nil || vaultCert == nil {
+		logger.Debugf("Serial check skipped for %s: could not get Vault cert: %v", domain, err)
+		return false, ""
+	}
+
+	servedCert, err := haproxyClient.GetServedCertificate(domain)
+	if err != nil {
+		logger.Debugf("Serial check skipped for %s: could not get served cert: %v", domain, err)
+		return false, ""
+	}
+
+	vaultSerial := haproxy.NormalizeSerial(vaultCert.SerialNumber.Text(16))
+	servedSerial := haproxy.NormalizeSerial(servedCert.SerialNumber.Text(16))
+
+	if vaultSerial != servedSerial {
+		return true, fmt.Sprintf("serial mismatch: vault=%s haproxy=%s", vaultSerial, servedSerial)
+	}
+	return false, ""
 }
 
 // endsWith checks if a string ends with a suffix

--- a/pkg/certmetrics/metrics.go
+++ b/pkg/certmetrics/metrics.go
@@ -50,6 +50,10 @@ var (
 		Name: "certificatee_certificates_total",
 		Help: "Total number of certificates managed per endpoint",
 	}, []string{"endpoint"})
+	CertificatesWildcard = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "certificatee_certificates_wildcard_total",
+		Help: "Number of certificates with wildcard (*) in their storage filename, indicating pre-migration format",
+	}, []string{"endpoint"})
 
 	// HAProxy endpoint health
 	HAProxyEndpointUp = promauto.NewGaugeVec(prometheus.GaugeOpts{

--- a/pkg/haproxy/client.go
+++ b/pkg/haproxy/client.go
@@ -3,11 +3,14 @@ package haproxy
 import (
 	"bytes"
 	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"fmt"
 	"io"
 	"mime/multipart"
+	"net"
 	"net/http"
+	"net/url"
 	"regexp"
 	"strings"
 	"time"
@@ -303,6 +306,62 @@ func ExtractDomainFromPath(certPath string) string {
 	}
 
 	return filename
+}
+
+// GetServedCertificate connects to the HAProxy HTTPS frontend on port 443 and returns
+// the leaf certificate served for the given domain via TLS SNI. This lets us detect
+// serial mismatches without relying on the Data Plane API storage endpoint.
+func (c *Client) GetServedCertificate(domain string) (*x509.Certificate, error) {
+	host, err := c.httpsHost()
+	if err != nil {
+		return nil, err
+	}
+
+	// HAProxy serves wildcard certs by SNI - need a concrete subdomain, not "*.foo" or "_.foo"
+	serverName := domain
+	if strings.HasPrefix(domain, "*.") || strings.HasPrefix(domain, "_.") {
+		serverName = "cert." + domain[2:]
+	}
+
+	conn, err := tls.DialWithDialer(
+		&net.Dialer{Timeout: c.timeout},
+		"tcp",
+		net.JoinHostPort(host, "443"),
+		&tls.Config{
+			ServerName:         serverName,
+			InsecureSkipVerify: true, //nolint:gosec // Intentional: we're reading the cert, not validating the chain
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("TLS dial to %s:443: %w", host, err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	certs := conn.ConnectionState().PeerCertificates
+	if len(certs) == 0 {
+		return nil, fmt.Errorf("no certificates in TLS handshake from %s", host)
+	}
+	return certs[0], nil
+}
+
+// httpsHost extracts the hostname from the DPAPI base URL.
+// Since DPAPI runs on the same node as HAProxy, this is the HTTPS frontend host.
+func (c *Client) httpsHost() (string, error) {
+	u, err := url.Parse(c.baseURL)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse base URL %s: %w", c.baseURL, err)
+	}
+	return u.Hostname(), nil
+}
+
+// NormalizeDomainForVault converts a sanitized cert filename domain back to the
+// Vault lookup key. HAProxy stores wildcard certs as "_.domain" on disk, but
+// certificator stores them in Vault as "*.domain".
+func NormalizeDomainForVault(domain string) string {
+	if strings.HasPrefix(domain, "_.") {
+		return "*." + domain[2:]
+	}
+	return domain
 }
 
 // IsExpiring checks if a certificate is expiring within the given number of days


### PR DESCRIPTION
## Summary

- **Fix wildcard cert Vault lookup** — HAProxy stores wildcard certs as `_.domain.pem` on disk, but certificator stores them in Vault as `*.domain`. `shouldUpdateCertificate` was doing a Vault lookup with `_.domain` which always returned not found, so wildcard certs were never updated. Added `NormalizeDomainForVault()` to convert `_.foo → *.foo` before any Vault call.

- **Fix stale cert detection (pit138 scenario)** — If Vault has a freshly renewed cert but HAProxy is still serving the expired one, `shouldUpdateCertificate` returned false (the Vault cert isn't expiring). Added `checkSerialMismatch()` which TLS-dials the HAProxy HTTPS frontend (`host:443`, same node as DPAPI), reads the live X.509 cert, and compares its serial to the Vault cert. If they differ → push. This bypasses DPAPI storage endpoint path normalization issues entirely.

- **Add `certificatee_certificates_wildcard_total` metric** — Counts how many certs per endpoint still have `*` in their storage name (pre-migration format). Used on the Grafana dashboard to track the `*.domain → _.domain` Rundeck migration progress.

## Files changed

- `pkg/certmetrics/metrics.go` — new `CertificatesWildcard` gauge
- `pkg/haproxy/client.go` — `GetServedCertificate()`, `NormalizeDomainForVault()`, `httpsHost()`
- `cmd/certificatee/main.go` — domain normalization, wildcard count, serial mismatch check

## Test plan

- [x] CI (`nix develop --command check`) passes
- [ ] After deploy: `certificatee_certificates_wildcard_total` appears in VictoriaMetrics
- [ ] Stale cert on pit138 staging gets pushed on next certificatee cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)