### PR TITLE
fix(goreleaser): add release trigger and fix missing certificator binary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,30 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  trigger-build:
+    runs-on: self-hosted
+    steps:
+      - name: Generate App Token
+        id: generate_token
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        with:
+          app-id: ${{ secrets.TRIGGER_APP_ID }}
+          private-key: ${{ secrets.TRIGGER_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: Binaries-ci
+
+      - name: Trigger Build
+        run: |
+          gh workflow run build-release.yml \
+            --repo ${{ github.repository_owner }}/Binaries-ci \
+            --ref main \
+            -f org=${{ github.repository_owner }} \
+            -f repo=${{ github.event.repository.name }} \
+            -f tag=${{ github.ref_name }}
+        env:
+          GH_TOKEN: ${{ steps.generate_token.outputs.token }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -27,9 +27,7 @@ builds:
       - amd64
 
 archives:
-  - formats: [tar.gz]
-    # Use .Binary so each build produces a distinct archive name:
-    # certificator_Linux_x86_64.tar.gz and certificatee_Linux_x86_64.tar.gz
+  - formats: [binary]
     name_template: >-
       {{ .Binary }}_
       {{- title .Os }}_

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -8,7 +8,8 @@ before:
     - go mod tidy
 
 builds:
-  - binary: certificator
+  - id: certificator
+    binary: certificator
     main: ./cmd/certificator
     env:
       - CGO_ENABLED=0


### PR DESCRIPTION
## Summary

- Add `.github/workflows/release.yml` to dispatch Binaries-ci build on tag push via `TRIGGER_APP_ID` GitHub App (same pattern as `rpc-configurator`)
- Fix goreleaser: add `id: certificator` to first build — without it, the archive only matched the explicitly-id'd `certificatee` build, silently omitting `certificator_Linux_x86_64` from the release
- Switch to `formats: [binary]` (raw binary) — consistent with exec driver Nomad jobs that use `mode = "file"`

## Root cause of v0.4.0 missing certificator binary

goreleaser applies archives to builds by `id`. The `certificatee` build had `id: certificatee` explicitly; the `certificator` build had no `id`, so goreleaser skipped it when archiving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)