### PR TITLE
feat(certificatee): switch to dataplaneapi v3 metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Certificatee uses the HAProxy Data Plane API to update certificates at runtime w
 - **Basic authentication**: Authenticate using username/password credentials
 - **Automatic retries**: Connections are retried with exponential backoff (default: 3 retries, 1-30s delays)
 - **Graceful degradation**: If one HAProxy instance is unreachable, the tool continues updating reachable instances
-- **REST API**: Certificates are managed via the `/v2/services/haproxy/runtime/certs` endpoints
+- **REST API**: Certificates are managed via the HAProxy Data Plane API v3 `/v3/services/haproxy/storage/ssl_certificates` endpoints
 
 ### HAProxy Data Plane API Configuration
 

--- a/cmd/certificatee/main.go
+++ b/cmd/certificatee/main.go
@@ -123,23 +123,24 @@ func processHAProxyEndpoint(logger *logrus.Logger, cfg config.Config, vaultClien
 		domain := haproxy.NormalizeDomainForVault(rawDomain)
 		logger.Debugf("[%s] Extracted domain '%s' from path '%s'", endpoint, domain, certPath)
 
-		// Check if certificate needs update (uses Vault as source of truth for cert details,
-		// since HAProxy Data Plane API doesn't provide certificate metadata)
-		shouldUpdate, reason, isExpiring, err := shouldUpdateCertificate(domain, vaultClient, cfg.Certificatee.RenewBeforeDays)
+		haproxyCert, err := haproxyClient.GetCertificateDetail(certPath)
+		if err != nil {
+			errs = append(errs, err)
+			logger.Errorf("[%s] failed to get dataplane metadata for %s: %v", endpoint, certPath, err)
+			continue
+		}
+
+		if !haproxyCert.NotAfter.IsZero() {
+			certmetrics.CertificateNotAfterTimestamp.WithLabelValues(endpoint, domain).Set(float64(haproxyCert.NotAfter.Unix()))
+		}
+
+		// Use Vault as the source of truth and HAProxy Data Plane API v3 metadata as
+		// the source of the currently loaded certificate state.
+		shouldUpdate, reason, isExpiring, err := shouldUpdateCertificate(domain, vaultClient, haproxyCert, cfg.Certificatee.RenewBeforeDays)
 		if err != nil {
 			errs = append(errs, err)
 			logger.Errorf("[%s] %v", endpoint, err)
 			continue
-		}
-
-		// Serial mismatch check: if Vault cert is not expiring but HAProxy is serving an older
-		// cert (e.g. cert was renewed but push failed, or HAProxy has expired cert post-renewal),
-		// detect it by comparing serial numbers via a live TLS dial.
-		if !shouldUpdate {
-			if serialUpdate, serialReason := checkSerialMismatch(domain, vaultClient, haproxyClient, logger); serialUpdate {
-				shouldUpdate = true
-				reason = serialReason
-			}
 		}
 
 		// Track expiring certificates
@@ -169,9 +170,7 @@ func processHAProxyEndpoint(logger *logrus.Logger, cfg config.Config, vaultClien
 	return errors.Join(errs...)
 }
 
-func shouldUpdateCertificate(domain string, vaultClient *vault.VaultClient, renewBeforeDays int) (shouldUpdate bool, reason string, isExpiring bool, err error) {
-	// Get certificate from Vault - this is the source of truth for certificate details
-	// (HAProxy Data Plane API doesn't provide certificate metadata like expiry or serial)
+func shouldUpdateCertificate(domain string, vaultClient *vault.VaultClient, haproxyCert *haproxy.CertificateDetail, renewBeforeDays int) (shouldUpdate bool, reason string, isExpiring bool, err error) {
 	vaultCert, err := certificate.GetCertificate(domain, vaultClient)
 	if err != nil {
 		return false, "", false, fmt.Errorf("failed to get certificate %s from vault: %w", domain, err)
@@ -181,13 +180,29 @@ func shouldUpdateCertificate(domain string, vaultClient *vault.VaultClient, rene
 		return false, "", false, fmt.Errorf("certificate for %s does not exist in vault", domain)
 	}
 
-	// Check if Vault certificate is expiring
+	if haproxyCert == nil {
+		return true, "certificate metadata missing in haproxy", true, nil
+	}
+
+	if haproxyCert.NotAfter.IsZero() {
+		return false, "", false, fmt.Errorf("certificate %s is missing not_after in haproxy metadata", domain)
+	}
+
 	threshold := time.Now().AddDate(0, 0, renewBeforeDays)
-	isExpiring = vaultCert.NotAfter.Before(threshold)
+	isExpiring = haproxyCert.NotAfter.Before(threshold)
 
 	if isExpiring {
-		// Certificate is expiring, sync to HAProxy (likely was recently renewed)
-		return true, fmt.Sprintf("certificate expires on %s (within %d days)", vaultCert.NotAfter.Format(time.RFC3339), renewBeforeDays), true, nil
+		return true, fmt.Sprintf("haproxy certificate expires on %s (within %d days)", haproxyCert.NotAfter.Format(time.RFC3339), renewBeforeDays), true, nil
+	}
+
+	vaultSerial := haproxy.NormalizeSerial(vaultCert.SerialNumber.Text(16))
+	haproxySerial := haproxy.NormalizeSerial(haproxyCert.Serial)
+	if haproxySerial != "" && vaultSerial != haproxySerial {
+		return true, fmt.Sprintf("serial mismatch: vault=%s haproxy=%s", vaultSerial, haproxySerial), false, nil
+	}
+
+	if vaultCert.NotAfter.After(haproxyCert.NotAfter) {
+		return true, fmt.Sprintf("vault certificate is newer: vault=%s haproxy=%s", vaultCert.NotAfter.Format(time.RFC3339), haproxyCert.NotAfter.Format(time.RFC3339)), false, nil
 	}
 
 	return false, "", false, nil
@@ -238,30 +253,6 @@ func buildPEMBundle(secrets map[string]any) (string, error) {
 	}
 
 	return pemData, nil
-}
-
-// checkSerialMismatch detects when HAProxy is serving a different cert than what's in Vault.
-// This catches cases where Vault has a freshly renewed cert but HAProxy still serves the old one.
-func checkSerialMismatch(domain string, vaultClient *vault.VaultClient, haproxyClient *haproxy.Client, logger *logrus.Logger) (bool, string) {
-	vaultCert, err := certificate.GetCertificate(domain, vaultClient)
-	if err != nil || vaultCert == nil {
-		logger.Debugf("Serial check skipped for %s: could not get Vault cert: %v", domain, err)
-		return false, ""
-	}
-
-	servedCert, err := haproxyClient.GetServedCertificate(domain)
-	if err != nil {
-		logger.Debugf("Serial check skipped for %s: could not get served cert: %v", domain, err)
-		return false, ""
-	}
-
-	vaultSerial := haproxy.NormalizeSerial(vaultCert.SerialNumber.Text(16))
-	servedSerial := haproxy.NormalizeSerial(servedCert.SerialNumber.Text(16))
-
-	if vaultSerial != servedSerial {
-		return true, fmt.Sprintf("serial mismatch: vault=%s haproxy=%s", vaultSerial, servedSerial)
-	}
-	return false, ""
 }
 
 // endsWith checks if a string ends with a suffix

--- a/pkg/certmetrics/metrics.go
+++ b/pkg/certmetrics/metrics.go
@@ -54,6 +54,10 @@ var (
 		Name: "certificatee_certificates_wildcard_total",
 		Help: "Number of certificates with wildcard (*) in their storage filename, indicating pre-migration format",
 	}, []string{"endpoint"})
+	CertificateNotAfterTimestamp = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "certificatee_certificate_not_after_timestamp_seconds",
+		Help: "Unix timestamp of the certificate not_after value reported by the HAProxy Data Plane API",
+	}, []string{"endpoint", "domain"})
 
 	// HAProxy endpoint health
 	HAProxyEndpointUp = promauto.NewGaugeVec(prometheus.GaugeOpts{

--- a/pkg/haproxy/client.go
+++ b/pkg/haproxy/client.go
@@ -3,15 +3,12 @@ package haproxy
 import (
 	"bytes"
 	"crypto/tls"
-	"crypto/x509"
 	"encoding/json"
 	"fmt"
 	"io"
 	"mime/multipart"
-	"net"
 	"net/http"
 	"net/url"
-	"regexp"
 	"strings"
 	"time"
 
@@ -133,11 +130,73 @@ func (c *Client) doRequest(method, path string, body io.Reader, contentType stri
 	return c.httpClient.Do(req)
 }
 
+func parseAPITime(value string) (time.Time, error) {
+	if value == "" {
+		return time.Time{}, nil
+	}
+
+	parsed, err := time.Parse(time.RFC3339Nano, value)
+	if err == nil {
+		return parsed, nil
+	}
+
+	return time.Parse(time.RFC3339, value)
+}
+
+func (c *Client) getConfigVersion() (string, error) {
+	resp, err := c.doRequest("GET", "/v3/services/haproxy/configuration/version", nil, "")
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return "", errors.Errorf("failed to get configuration version: status %d, body: %s", resp.StatusCode, string(body))
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to read configuration version")
+	}
+
+	version := strings.TrimSpace(string(body))
+	if version == "" {
+		return "", errors.New("empty configuration version response")
+	}
+
+	return version, nil
+}
+
 // SSLCertificateEntry represents an SSL certificate entry from storage API
 type SSLCertificateEntry struct {
 	File        string `json:"file"`
 	StorageName string `json:"storage_name"`
 	Description string `json:"description"`
+}
+
+type sslCertificateDetailResponse struct {
+	File        string `json:"file"`
+	StorageName string `json:"storage_name"`
+	Description string `json:"description"`
+	Domains     string `json:"domains"`
+	Issuers     string `json:"issuers"`
+	NotAfter    string `json:"not_after"`
+	NotBefore   string `json:"not_before"`
+	Serial      string `json:"serial"`
+}
+
+// CertificateDetail describes the current HAProxy certificate state reported by
+// the Data Plane API.
+type CertificateDetail struct {
+	File        string
+	StorageName string
+	Description string
+	Domains     string
+	Issuers     string
+	NotAfter    time.Time
+	NotBefore   time.Time
+	Serial      string
 }
 
 // CertificateRef holds both display name and file path for a certificate
@@ -165,7 +224,7 @@ func (c *Client) ListCertificates() ([]string, error) {
 // ListCertificateRefs returns a list of certificate references with both display names and file paths
 func (c *Client) ListCertificateRefs() ([]CertificateRef, error) {
 	// Use storage API endpoint for listing SSL certificates
-	resp, err := c.doRequest("GET", "/v2/services/haproxy/storage/ssl_certificates", nil, "")
+	resp, err := c.doRequest("GET", "/v3/services/haproxy/storage/ssl_certificates", nil, "")
 	if err != nil {
 		return nil, err
 	}
@@ -200,28 +259,58 @@ func (c *Client) ListCertificateRefs() ([]CertificateRef, error) {
 	return refs, nil
 }
 
+// GetCertificateDetail returns Data Plane API metadata for a specific
+// certificate file.
+func (c *Client) GetCertificateDetail(certName string) (*CertificateDetail, error) {
+	path := fmt.Sprintf("/v3/services/haproxy/storage/ssl_certificates/%s", url.PathEscape(certName))
+	resp, err := c.doRequest("GET", path, nil, "")
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, errors.Errorf("failed to get certificate %s: status %d, body: %s", certName, resp.StatusCode, string(body))
+	}
+
+	var raw sslCertificateDetailResponse
+	if err := json.NewDecoder(resp.Body).Decode(&raw); err != nil {
+		return nil, errors.Wrap(err, "failed to decode certificate detail")
+	}
+
+	notAfter, err := parseAPITime(raw.NotAfter)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to parse not_after for certificate %s", certName)
+	}
+
+	notBefore, err := parseAPITime(raw.NotBefore)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to parse not_before for certificate %s", certName)
+	}
+
+	return &CertificateDetail{
+		File:        raw.File,
+		StorageName: raw.StorageName,
+		Description: raw.Description,
+		Domains:     raw.Domains,
+		Issuers:     raw.Issuers,
+		NotAfter:    notAfter,
+		NotBefore:   notBefore,
+		Serial:      raw.Serial,
+	}, nil
+}
+
 // UpdateCertificate uploads and commits a certificate update via Data Plane API
 func (c *Client) UpdateCertificate(certName, pemData string) error {
-	// Create multipart form data
-	var buf bytes.Buffer
-	writer := multipart.NewWriter(&buf)
-
-	// Add file part
-	part, err := writer.CreateFormFile("file_upload", certName)
+	version, err := c.getConfigVersion()
 	if err != nil {
-		return errors.Wrap(err, "failed to create form file")
-	}
-	if _, err := part.Write([]byte(pemData)); err != nil {
-		return errors.Wrap(err, "failed to write certificate data")
-	}
-
-	if err := writer.Close(); err != nil {
-		return errors.Wrap(err, "failed to close multipart writer")
+		return err
 	}
 
 	// Send PUT request to replace certificate
-	path := fmt.Sprintf("/v2/services/haproxy/runtime/certs/%s", certName)
-	resp, err := c.doRequest("PUT", path, &buf, writer.FormDataContentType())
+	path := fmt.Sprintf("/v3/services/haproxy/storage/ssl_certificates/%s?version=%s", url.PathEscape(certName), url.QueryEscape(version))
+	resp, err := c.doRequest("PUT", path, strings.NewReader(pemData), "text/plain")
 	if err != nil {
 		return err
 	}
@@ -238,6 +327,11 @@ func (c *Client) UpdateCertificate(certName, pemData string) error {
 
 // CreateCertificate creates a new certificate entry via Data Plane API
 func (c *Client) CreateCertificate(certName, pemData string) error {
+	version, err := c.getConfigVersion()
+	if err != nil {
+		return err
+	}
+
 	// Create multipart form data
 	var buf bytes.Buffer
 	writer := multipart.NewWriter(&buf)
@@ -256,7 +350,8 @@ func (c *Client) CreateCertificate(certName, pemData string) error {
 	}
 
 	// Send POST request to create certificate
-	resp, err := c.doRequest("POST", "/v2/services/haproxy/runtime/certs", &buf, writer.FormDataContentType())
+	path := fmt.Sprintf("/v3/services/haproxy/storage/ssl_certificates?version=%s", url.QueryEscape(version))
+	resp, err := c.doRequest("POST", path, &buf, writer.FormDataContentType())
 	if err != nil {
 		return err
 	}
@@ -273,7 +368,12 @@ func (c *Client) CreateCertificate(certName, pemData string) error {
 
 // DeleteCertificate deletes a certificate entry via Data Plane API
 func (c *Client) DeleteCertificate(certName string) error {
-	path := fmt.Sprintf("/v2/services/haproxy/runtime/certs/%s", certName)
+	version, err := c.getConfigVersion()
+	if err != nil {
+		return err
+	}
+
+	path := fmt.Sprintf("/v3/services/haproxy/storage/ssl_certificates/%s?version=%s", url.PathEscape(certName), url.QueryEscape(version))
 	resp, err := c.doRequest("DELETE", path, nil, "")
 	if err != nil {
 		return err
@@ -308,52 +408,6 @@ func ExtractDomainFromPath(certPath string) string {
 	return filename
 }
 
-// GetServedCertificate connects to the HAProxy HTTPS frontend on port 443 and returns
-// the leaf certificate served for the given domain via TLS SNI. This lets us detect
-// serial mismatches without relying on the Data Plane API storage endpoint.
-func (c *Client) GetServedCertificate(domain string) (*x509.Certificate, error) {
-	host, err := c.httpsHost()
-	if err != nil {
-		return nil, err
-	}
-
-	// HAProxy serves wildcard certs by SNI - need a concrete subdomain, not "*.foo" or "_.foo"
-	serverName := domain
-	if strings.HasPrefix(domain, "*.") || strings.HasPrefix(domain, "_.") {
-		serverName = "cert." + domain[2:]
-	}
-
-	conn, err := tls.DialWithDialer(
-		&net.Dialer{Timeout: c.timeout},
-		"tcp",
-		net.JoinHostPort(host, "443"),
-		&tls.Config{
-			ServerName:         serverName,
-			InsecureSkipVerify: true, //nolint:gosec // Intentional: we're reading the cert, not validating the chain
-		},
-	)
-	if err != nil {
-		return nil, fmt.Errorf("TLS dial to %s:443: %w", host, err)
-	}
-	defer func() { _ = conn.Close() }()
-
-	certs := conn.ConnectionState().PeerCertificates
-	if len(certs) == 0 {
-		return nil, fmt.Errorf("no certificates in TLS handshake from %s", host)
-	}
-	return certs[0], nil
-}
-
-// httpsHost extracts the hostname from the DPAPI base URL.
-// Since DPAPI runs on the same node as HAProxy, this is the HTTPS frontend host.
-func (c *Client) httpsHost() (string, error) {
-	u, err := url.Parse(c.baseURL)
-	if err != nil {
-		return "", fmt.Errorf("failed to parse base URL %s: %w", c.baseURL, err)
-	}
-	return u.Hostname(), nil
-}
-
 // NormalizeDomainForVault converts a sanitized cert filename domain back to the
 // Vault lookup key. HAProxy stores wildcard certs as "_.domain" on disk, but
 // certificator stores them in Vault as "*.domain".
@@ -374,11 +428,24 @@ func IsExpiring(certInfo *CertInfo, renewBeforeDays int) bool {
 	return certInfo.NotAfter.Before(threshold)
 }
 
-// NormalizeSerial normalizes a certificate serial number for comparison
-// Removes colons, spaces, and converts to uppercase
+// NormalizeSerial normalizes a certificate serial number for comparison.
+// Removes non-hex characters and converts to uppercase.
 func NormalizeSerial(serial string) string {
-	re := regexp.MustCompile(`[^a-fA-F0-9]`)
-	return strings.ToUpper(re.ReplaceAllString(serial, ""))
+	var b strings.Builder
+	b.Grow(len(serial))
+
+	for _, ch := range serial {
+		switch {
+		case ch >= '0' && ch <= '9':
+			b.WriteRune(ch)
+		case ch >= 'a' && ch <= 'f':
+			b.WriteRune(ch - ('a' - 'A'))
+		case ch >= 'A' && ch <= 'F':
+			b.WriteRune(ch)
+		}
+	}
+
+	return b.String()
 }
 
 // logrusLeveledLogger wraps a logrus.Logger to implement retryablehttp.LeveledLogger

--- a/pkg/haproxy/client_test.go
+++ b/pkg/haproxy/client_test.go
@@ -322,7 +322,7 @@ func newMockDataPlaneAPI(t *testing.T) *mockDataPlaneAPI {
 			return
 		}
 
-		// Try prefix matching for dynamic paths (e.g., /v2/services/haproxy/runtime/certs/example.com.pem)
+		// Try prefix matching for dynamic paths (e.g., /v3/services/haproxy/storage/ssl_certificates/example.com.pem)
 		for pattern, handler := range m.handlers {
 			if strings.HasPrefix(key, pattern) {
 				handler(w, r)
@@ -416,7 +416,7 @@ func TestListCertificates(t *testing.T) {
 			mock := newMockDataPlaneAPI(t)
 			defer mock.Close()
 
-			mock.SetHandler("GET", "/v2/services/haproxy/storage/ssl_certificates", func(w http.ResponseWriter, r *http.Request) {
+			mock.SetHandler("GET", "/v3/services/haproxy/storage/ssl_certificates", func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(tt.statusCode)
 				if tt.response != nil {
@@ -496,29 +496,27 @@ func TestUpdateCertificate(t *testing.T) {
 			mock := newMockDataPlaneAPI(t)
 			defer mock.Close()
 
-			mock.SetHandler("PUT", "/v2/services/haproxy/runtime/certs/"+tt.certName, func(w http.ResponseWriter, r *http.Request) {
-				// Verify content type is multipart
+			mock.SetHandler("GET", "/v3/services/haproxy/configuration/version", func(w http.ResponseWriter, r *http.Request) {
+				_, _ = w.Write([]byte("42"))
+			})
+
+			mock.SetHandler("PUT", "/v3/services/haproxy/storage/ssl_certificates/"+tt.certName, func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Query().Get("version") != "42" {
+					t.Errorf("version query = %q, want %q", r.URL.Query().Get("version"), "42")
+				}
+
+				// Verify content type is plain text
 				contentType := r.Header.Get("Content-Type")
-				if !strings.Contains(contentType, "multipart/form-data") {
-					t.Errorf("Expected multipart/form-data content type, got %s", contentType)
+				if !strings.Contains(contentType, "text/plain") {
+					t.Errorf("Expected text/plain content type, got %s", contentType)
 				}
 
-				// Read the multipart form
-				err := r.ParseMultipartForm(10 << 20) // 10 MB
+				data, err := io.ReadAll(r.Body)
 				if err != nil {
-					t.Errorf("Failed to parse multipart form: %v", err)
+					t.Errorf("Failed to read request body: %v", err)
 				}
-
-				// Verify file was uploaded
-				file, _, err := r.FormFile("file_upload")
-				if err != nil {
-					t.Errorf("Failed to get file from form: %v", err)
-				} else {
-					defer func() { _ = file.Close() }()
-					data, _ := io.ReadAll(file)
-					if string(data) != tt.pemData {
-						t.Errorf("File data = %q, want %q", string(data), tt.pemData)
-					}
+				if string(data) != tt.pemData {
+					t.Errorf("File data = %q, want %q", string(data), tt.pemData)
 				}
 
 				w.WriteHeader(tt.statusCode)
@@ -534,6 +532,51 @@ func TestUpdateCertificate(t *testing.T) {
 				t.Errorf("UpdateCertificate() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
+	}
+}
+
+func TestGetCertificateDetail(t *testing.T) {
+	logger := logrus.New()
+	logger.SetLevel(logrus.PanicLevel)
+
+	mock := newMockDataPlaneAPI(t)
+	defer mock.Close()
+
+	mock.SetHandler("GET", "/v3/services/haproxy/storage/ssl_certificates/example.com.pem", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"file":         "/etc/haproxy/ssl/example.com.pem",
+			"storage_name": "example.com.pem",
+			"description":  "managed SSL file",
+			"domains":      "example.com",
+			"issuers":      "Example CA",
+			"not_after":    "2026-09-13T09:00:00.000Z",
+			"not_before":   "2025-09-13T09:00:00.000Z",
+			"serial":       "1f:52:02:e0",
+		})
+	})
+
+	client, err := NewClient(ClientConfig{BaseURL: mock.URL()}, logger)
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+
+	detail, err := client.GetCertificateDetail("example.com.pem")
+	if err != nil {
+		t.Fatalf("GetCertificateDetail() error = %v", err)
+	}
+
+	if detail.StorageName != "example.com.pem" {
+		t.Errorf("StorageName = %q, want %q", detail.StorageName, "example.com.pem")
+	}
+	if detail.Domains != "example.com" {
+		t.Errorf("Domains = %q, want %q", detail.Domains, "example.com")
+	}
+	if detail.Serial != "1f:52:02:e0" {
+		t.Errorf("Serial = %q, want %q", detail.Serial, "1f:52:02:e0")
+	}
+	if detail.NotAfter.IsZero() {
+		t.Error("NotAfter should be parsed")
 	}
 }
 
@@ -583,7 +626,15 @@ func TestCreateCertificate(t *testing.T) {
 			mock := newMockDataPlaneAPI(t)
 			defer mock.Close()
 
-			mock.SetHandler("POST", "/v2/services/haproxy/runtime/certs", func(w http.ResponseWriter, r *http.Request) {
+			mock.SetHandler("GET", "/v3/services/haproxy/configuration/version", func(w http.ResponseWriter, r *http.Request) {
+				_, _ = w.Write([]byte("42"))
+			})
+
+			mock.SetHandler("POST", "/v3/services/haproxy/storage/ssl_certificates", func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Query().Get("version") != "42" {
+					t.Errorf("version query = %q, want %q", r.URL.Query().Get("version"), "42")
+				}
+
 				// Verify content type is multipart
 				contentType := r.Header.Get("Content-Type")
 				if !strings.Contains(contentType, "multipart/form-data") {
@@ -668,7 +719,14 @@ func TestDeleteCertificate(t *testing.T) {
 			mock := newMockDataPlaneAPI(t)
 			defer mock.Close()
 
-			mock.SetHandler("DELETE", "/v2/services/haproxy/runtime/certs/"+tt.certName, func(w http.ResponseWriter, r *http.Request) {
+			mock.SetHandler("GET", "/v3/services/haproxy/configuration/version", func(w http.ResponseWriter, r *http.Request) {
+				_, _ = w.Write([]byte("42"))
+			})
+
+			mock.SetHandler("DELETE", "/v3/services/haproxy/storage/ssl_certificates/"+tt.certName, func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Query().Get("version") != "42" {
+					t.Errorf("version query = %q, want %q", r.URL.Query().Get("version"), "42")
+				}
 				w.WriteHeader(tt.statusCode)
 			})
 
@@ -693,7 +751,7 @@ func TestBasicAuth(t *testing.T) {
 	defer mock.Close()
 	mock.SetAuth("admin", "secret")
 
-	mock.SetHandler("GET", "/v2/services/haproxy/storage/ssl_certificates", func(w http.ResponseWriter, r *http.Request) {
+	mock.SetHandler("GET", "/v3/services/haproxy/storage/ssl_certificates", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		_ = json.NewEncoder(w).Encode([]SSLCertificateEntry{})


### PR DESCRIPTION
## Summary
- switch certificatee to HAProxy Data Plane API v3 only
- use DPAPI certificate metadata for expiry and serial checks instead of TLS probing
- publish per-certificate not_after timestamps from DPAPI metadata

## Details
- move certificate list/detail/write paths to /v3/services/haproxy/storage/ssl_certificates
- fetch /v3/services/haproxy/configuration/version and pass version on write operations
- replace the TLS endpoint serial mismatch path with Data Plane API metadata lookups
- update tests and README to match the v3-only behavior

## Verification
- go test -v ./pkg/haproxy
- go test -v ./cmd/certificatee
