### PR TITLE
fix(certificatee): fallback when dataplane detail is missing

### DIFF
--- a/cmd/certificatee/main.go
+++ b/cmd/certificatee/main.go
@@ -125,9 +125,16 @@ func processHAProxyEndpoint(logger *logrus.Logger, cfg config.Config, vaultClien
 
 		haproxyCert, err := haproxyClient.GetCertificateDetail(certPath)
 		if err != nil {
-			errs = append(errs, err)
-			logger.Errorf("[%s] failed to get dataplane metadata for %s: %v", endpoint, certPath, err)
-			continue
+			certmetrics.CertificateMetadataLookupFailures.WithLabelValues(endpoint, domain).Inc()
+
+			if strings.Contains(err.Error(), "status 404") {
+				logger.Warnf("[%s] missing dataplane metadata for %s, falling back to vault expiry only: %v", endpoint, certPath, err)
+				haproxyCert = nil
+			} else {
+				errs = append(errs, err)
+				logger.Errorf("[%s] failed to get dataplane metadata for %s: %v", endpoint, certPath, err)
+				continue
+			}
 		}
 
 		if !haproxyCert.NotAfter.IsZero() {
@@ -181,7 +188,12 @@ func shouldUpdateCertificate(domain string, vaultClient *vault.VaultClient, hapr
 	}
 
 	if haproxyCert == nil {
-		return true, "certificate metadata missing in haproxy", true, nil
+		threshold := time.Now().AddDate(0, 0, renewBeforeDays)
+		isExpiring = vaultCert.NotAfter.Before(threshold)
+		if isExpiring {
+			return true, fmt.Sprintf("vault certificate expires on %s (haproxy metadata unavailable)", vaultCert.NotAfter.Format(time.RFC3339)), true, nil
+		}
+		return false, "", false, nil
 	}
 
 	if haproxyCert.NotAfter.IsZero() {

--- a/pkg/certmetrics/metrics.go
+++ b/pkg/certmetrics/metrics.go
@@ -58,6 +58,10 @@ var (
 		Name: "certificatee_certificate_not_after_timestamp_seconds",
 		Help: "Unix timestamp of the certificate not_after value reported by the HAProxy Data Plane API",
 	}, []string{"endpoint", "domain"})
+	CertificateMetadataLookupFailures = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "certificatee_certificate_metadata_lookup_failures_total",
+		Help: "Total number of HAProxy Data Plane API per-certificate metadata lookup failures",
+	}, []string{"endpoint", "domain"})
 
 	// HAProxy endpoint health
 	HAProxyEndpointUp = promauto.NewGaugeVec(prometheus.GaugeOpts{


### PR DESCRIPTION
## Summary
- avoid failing an entire HAProxy endpoint when per-certificate DPAPI v3 detail lookups return 404
- fall back to vault-expiry-only decisions when certificate detail metadata is unavailable
- publish a counter for per-certificate metadata lookup failures

## Context
The v3 list endpoint successfully enumerates certificates, including wildcard-style names like , but some follow-up detail lookups return 404 from the live Data Plane API. This caused certificatee to treat the whole endpoint as failed even though enumeration succeeded.

## Behavior
- increment  on per-certificate detail lookup failures
- treat 404 detail misses as non-fatal and continue processing the rest of the endpoint
- if metadata is unavailable for a cert, fall back to Vault expiry only instead of forcing an update or failing the endpoint

## Verification
- 
