### PR TITLE
feat: add certificatee health endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,9 @@ Certificate files must be named after the domain (e.g., `/etc/haproxy/certs/exam
 
 Certificatee exposes Prometheus metrics for monitoring:
 
+- `GET /metrics` exposes Prometheus metrics.
+- `GET /health` returns `200 OK` only when the process can still reach Vault, can query its configured HAProxy Data Plane API endpoints, and `certificatee` has completed a recent successful sync.
+
 ### General Metrics
 
 | Metric | Type | Labels | Description |

--- a/cmd/certificatee/health.go
+++ b/cmd/certificatee/health.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/vinted/certificator/pkg/haproxy"
+	"github.com/vinted/certificator/pkg/vault"
+)
+
+type syncHealthState struct {
+	mu              sync.RWMutex
+	lastSuccess     time.Time
+	lastFailure     time.Time
+	lastFailureText string
+}
+
+func (s *syncHealthState) Mark(err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if err == nil {
+		s.lastSuccess = time.Now()
+		s.lastFailureText = ""
+		return
+	}
+
+	s.lastFailure = time.Now()
+	s.lastFailureText = err.Error()
+}
+
+func (s *syncHealthState) Check(maxAge time.Duration) error {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if s.lastSuccess.IsZero() {
+		if s.lastFailureText != "" {
+			return fmt.Errorf("initial sync has not succeeded yet: %s", s.lastFailureText)
+		}
+		return fmt.Errorf("initial sync has not succeeded yet")
+	}
+
+	if time.Since(s.lastSuccess) > maxAge {
+		if s.lastFailureText != "" {
+			return fmt.Errorf("last successful sync is stale (%s ago): %s", time.Since(s.lastSuccess).Round(time.Second), s.lastFailureText)
+		}
+		return fmt.Errorf("last successful sync is stale (%s ago)", time.Since(s.lastSuccess).Round(time.Second))
+	}
+
+	return nil
+}
+
+func newCertificateeHealthChecker(vaultClient *vault.VaultClient, haproxyClients []*haproxy.Client, state *syncHealthState, updateInterval time.Duration) func(context.Context) error {
+	maxSyncAge := updateInterval * 2
+	if maxSyncAge < time.Minute {
+		maxSyncAge = time.Minute
+	}
+
+	return func(ctx context.Context) error {
+		if err := vaultClient.TokenLookupSelf(); err != nil {
+			return err
+		}
+
+		var errs []error
+		for _, client := range haproxyClients {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+
+			if _, err := client.ListCertificateRefs(); err != nil {
+				errs = append(errs, fmt.Errorf("%s: %w", client.Endpoint(), err))
+			}
+		}
+
+		if err := state.Check(maxSyncAge); err != nil {
+			errs = append(errs, err)
+		}
+
+		return errors.Join(errs...)
+	}
+}

--- a/cmd/certificatee/main.go
+++ b/cmd/certificatee/main.go
@@ -33,9 +33,6 @@ func main() {
 		logger.Fatal("HAPROXY_DATAPLANE_API_URLS must be set (comma-separated list of Data Plane API URLs)")
 	}
 
-	certmetrics.StartMetricsServer(logger, cfg.Metrics.ListenAddress)
-	defer certmetrics.PushMetrics(logger, cfg.Metrics.PushUrl)
-
 	vaultClient, err := vault.NewVaultClient(cfg.Vault.ApproleRoleID,
 		cfg.Vault.ApproleSecretID, cfg.Environment, cfg.Vault.KVStoragePath, logger)
 	if err != nil {
@@ -46,6 +43,10 @@ func main() {
 	if err != nil {
 		logger.Fatal(err)
 	}
+
+	healthState := &syncHealthState{}
+	certmetrics.StartMetricsServer(logger, cfg.Metrics.ListenAddress, newCertificateeHealthChecker(vaultClient, haproxyClients, healthState, cfg.Certificatee.UpdateInterval))
+	defer certmetrics.PushMetrics(logger, cfg.Metrics.PushUrl)
 
 	logger.Infof("Configured %d HAProxy endpoint(s)", len(haproxyClients))
 	for _, client := range haproxyClients {
@@ -60,13 +61,19 @@ func main() {
 
 	// Initial run
 	if err := maybeUpdateCertificates(logger, cfg, vaultClient, haproxyClients); err != nil {
+		healthState.Mark(err)
 		logger.Error(err)
+	} else {
+		healthState.Mark(nil)
 	}
 
 	for range ticker.C {
 		if err := maybeUpdateCertificates(logger, cfg, vaultClient, haproxyClients); err != nil {
+			healthState.Mark(err)
 			logger.Error(err)
+			continue
 		}
+		healthState.Mark(nil)
 	}
 }
 

--- a/cmd/certificator/main.go
+++ b/cmd/certificator/main.go
@@ -26,14 +26,19 @@ func main() {
 	logger := cfg.Log.Logger
 	legoLog.Logger = logger
 
-	certmetrics.StartMetricsServer(logger, cfg.Metrics.ListenAddress)
-	defer certmetrics.PushMetrics(logger, cfg.Metrics.PushUrl)
-
 	vaultClient, err := vault.NewVaultClient(cfg.Vault.ApproleRoleID,
 		cfg.Vault.ApproleSecretID, cfg.Environment, cfg.Vault.KVStoragePath, logger)
 	if err != nil {
 		logger.Fatal(err)
 	}
+
+	certmetrics.StartMetricsServer(logger, cfg.Metrics.ListenAddress, func(ctx context.Context) error {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		return vaultClient.TokenLookupSelf()
+	})
+	defer certmetrics.PushMetrics(logger, cfg.Metrics.PushUrl)
 
 	acmeClient, err := acme.NewClient(cfg.Acme.AccountEmail, cfg.Acme.ServerURL, cfg.Acme.EABKid, cfg.Acme.EABHmacKey,
 		cfg.Acme.ReregisterAccount, vaultClient, logger)

--- a/pkg/certmetrics/metrics.go
+++ b/pkg/certmetrics/metrics.go
@@ -2,6 +2,7 @@ package certmetrics
 
 import (
 	"bytes"
+	"context"
 	"net/http"
 	"time"
 
@@ -11,6 +12,8 @@ import (
 	"github.com/prometheus/common/expfmt"
 	"github.com/sirupsen/logrus"
 )
+
+type HealthChecker func(context.Context) error
 
 var (
 	// Shared metrics
@@ -70,15 +73,20 @@ var (
 	}, []string{"endpoint"})
 )
 
-func StartMetricsServer(logger *logrus.Logger, address string) {
+func StartMetricsServer(logger *logrus.Logger, address string, healthCheckers ...HealthChecker) {
 	if address == "" {
 		logger.Debug("metrics listen address is empty, skipping metrics server start")
 		return
 	}
 
+	var healthChecker HealthChecker
+	if len(healthCheckers) > 0 {
+		healthChecker = healthCheckers[0]
+	}
+
 	metricsServer := &http.Server{
 		Addr:              address,
-		Handler:           promhttp.Handler(),
+		Handler:           newHandler(healthChecker),
 		ReadHeaderTimeout: 100 * time.Millisecond,
 	}
 
@@ -88,6 +96,30 @@ func StartMetricsServer(logger *logrus.Logger, address string) {
 			logger.Errorf("metrics server error: %v", err)
 		}
 	}()
+}
+
+func newHandler(healthChecker HealthChecker) http.Handler {
+	mux := http.NewServeMux()
+	mux.Handle("/metrics", promhttp.Handler())
+	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		if healthChecker == nil {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("ok\n"))
+			return
+		}
+
+		ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
+		defer cancel()
+
+		if err := healthChecker(ctx); err != nil {
+			http.Error(w, err.Error(), http.StatusServiceUnavailable)
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok\n"))
+	})
+	return mux
 }
 
 func PushMetrics(logger *logrus.Logger, pushUrl string) {

--- a/pkg/certmetrics/metrics_test.go
+++ b/pkg/certmetrics/metrics_test.go
@@ -1,0 +1,56 @@
+package certmetrics
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestHealthHandlerWithoutChecker(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	rec := httptest.NewRecorder()
+
+	newHandler(nil).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	if body := rec.Body.String(); body != "ok\n" {
+		t.Fatalf("body = %q, want %q", body, "ok\n")
+	}
+}
+
+func TestHealthHandlerWithFailingChecker(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	rec := httptest.NewRecorder()
+
+	newHandler(func(context.Context) error {
+		return errors.New("vault unavailable")
+	}).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusServiceUnavailable)
+	}
+	if body := rec.Body.String(); !strings.Contains(body, "vault unavailable") {
+		t.Fatalf("body = %q, want substring %q", body, "vault unavailable")
+	}
+}
+
+func TestHealthHandlerWithPassingChecker(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	rec := httptest.NewRecorder()
+
+	newHandler(func(context.Context) error {
+		return nil
+	}).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	if body := rec.Body.String(); body != "ok\n" {
+		t.Fatalf("body = %q, want %q", body, "ok\n")
+	}
+}

--- a/pkg/vault/vault.go
+++ b/pkg/vault/vault.go
@@ -23,6 +23,18 @@ func NewVaultClient(roleID, secretID, env, kvPrefix string, logger *logrus.Logge
 	return &VaultClient{client: client, kvPrefix: kvPrefix, logger: logger}, nil
 }
 
+// TokenLookupSelf verifies that the current Vault token is valid.
+func (cl *VaultClient) TokenLookupSelf() error {
+	resp, err := cl.client.Auth().Token().LookupSelf()
+	if err != nil {
+		return fmt.Errorf("failed looking up Vault token: %w", err)
+	}
+	if resp == nil {
+		return fmt.Errorf("vault token lookup returned nil response")
+	}
+	return nil
+}
+
 // KVWrite writes value to vault key value v2 storage
 func (cl *VaultClient) KVWrite(path string, value map[string]string) error {
 	fullPath := vaultFullPath(path, cl.kvPrefix)


### PR DESCRIPTION
## Summary
- add a real /health endpoint alongside /metrics
- make certificatee health depend on Vault access, HAProxy Data Plane API reachability, and a recent successful sync
- expose the same endpoint shape from certificator with a Vault token check and add handler tests

## Testing
- env GOCACHE=/tmp/go-build-certificator go test ./pkg/certmetrics ./cmd/certificatee ./cmd/certificator