### PR TITLE
feat: add certificatee rollout-tolerant health checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ A daemon that synchronizes certificates from Vault to HAProxy using the HAProxy 
 - The certificate is expiring within the configured threshold (default: 30 days)
 - The certificate serial number differs from the one stored in Vault
 
+During rollout, `certificatee` tolerates mixed HAProxy Data Plane API versions. If an endpoint is still on v2, unreachable, or unhealthy, `certificatee` itself stays healthy, reports the endpoint state via metrics, and starts syncing automatically once the v3 certificate storage API becomes available.
+
 ## Configuration
 
 ### Certificatee Environment Variables
@@ -60,6 +62,7 @@ Certificatee uses the HAProxy Data Plane API to update certificates at runtime w
 - **Automatic retries**: Connections are retried with exponential backoff (default: 3 retries, 1-30s delays)
 - **Graceful degradation**: If one HAProxy instance is unreachable, the tool continues updating reachable instances
 - **REST API**: Certificates are managed via the HAProxy Data Plane API v3 `/v3/services/haproxy/storage/ssl_certificates` endpoints
+- **Mixed-version rollout tolerance**: v2-only endpoints are treated as waiting, not fatal, until the v3 certificate storage API is available
 
 ### HAProxy Data Plane API Configuration
 
@@ -87,7 +90,7 @@ Certificate files must be named after the domain (e.g., `/etc/haproxy/certs/exam
 Certificatee exposes Prometheus metrics for monitoring:
 
 - `GET /metrics` exposes Prometheus metrics.
-- `GET /health` returns `200 OK` only when the process can still reach Vault, can query its configured HAProxy Data Plane API endpoints, and `certificatee` has completed a recent successful sync.
+- `GET /health` returns `200 OK` when the process can still reach Vault. HAProxy Data Plane API reachability and rollout state are reported via metrics and do not make the process unhealthy in Nomad.
 
 ### General Metrics
 
@@ -101,7 +104,9 @@ Certificatee exposes Prometheus metrics for monitoring:
 
 | Metric | Type | Labels | Description |
 |--------|------|--------|-------------|
-| `certificatee_haproxy_endpoint_up` | Gauge | endpoint | HAProxy endpoint reachability (1=up, 0=down) |
+| `certificatee_haproxy_endpoint_up` | Gauge | endpoint, state | Endpoint rollout state. `state="reachable"` means the DPAPI endpoint is reachable, `state="v3_ready"` means the v3 certificate storage API is available, and `state="working"` means certificatee is actively syncing that endpoint |
+| `certificatee_certificate_not_after_timestamp_seconds` | Gauge | endpoint, domain | Certificate expiry reported by the HAProxy Data Plane API |
+| `certificatee_certificate_metadata_lookup_failures_total` | Counter | endpoint, domain | Per-certificate DPAPI metadata lookups that failed and fell back to Vault-only expiry checks |
 | `certificatee_haproxy_connections_total` | Counter | endpoint, status | Total connection attempts (status: success/failure) |
 | `certificatee_haproxy_connection_retries_total` | Counter | endpoint | Connection retry attempts |
 | `certificatee_haproxy_certificates_checked_total` | Counter | endpoint | Certificates checked per endpoint |

--- a/cmd/certificatee/health.go
+++ b/cmd/certificatee/health.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+
 	"github.com/vinted/certificator/pkg/vault"
 )
 

--- a/cmd/certificatee/health.go
+++ b/cmd/certificatee/health.go
@@ -4,61 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"sync"
-	"time"
 
 	"github.com/vinted/certificator/pkg/haproxy"
 	"github.com/vinted/certificator/pkg/vault"
 )
 
-type syncHealthState struct {
-	mu              sync.RWMutex
-	lastSuccess     time.Time
-	lastFailure     time.Time
-	lastFailureText string
-}
-
-func (s *syncHealthState) Mark(err error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	if err == nil {
-		s.lastSuccess = time.Now()
-		s.lastFailureText = ""
-		return
-	}
-
-	s.lastFailure = time.Now()
-	s.lastFailureText = err.Error()
-}
-
-func (s *syncHealthState) Check(maxAge time.Duration) error {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-
-	if s.lastSuccess.IsZero() {
-		if s.lastFailureText != "" {
-			return fmt.Errorf("initial sync has not succeeded yet: %s", s.lastFailureText)
-		}
-		return fmt.Errorf("initial sync has not succeeded yet")
-	}
-
-	if time.Since(s.lastSuccess) > maxAge {
-		if s.lastFailureText != "" {
-			return fmt.Errorf("last successful sync is stale (%s ago): %s", time.Since(s.lastSuccess).Round(time.Second), s.lastFailureText)
-		}
-		return fmt.Errorf("last successful sync is stale (%s ago)", time.Since(s.lastSuccess).Round(time.Second))
-	}
-
-	return nil
-}
-
-func newCertificateeHealthChecker(vaultClient *vault.VaultClient, haproxyClients []*haproxy.Client, state *syncHealthState, updateInterval time.Duration) func(context.Context) error {
-	maxSyncAge := updateInterval * 2
-	if maxSyncAge < time.Minute {
-		maxSyncAge = time.Minute
-	}
-
+func newCertificateeHealthChecker(vaultClient *vault.VaultClient, haproxyClients []*haproxy.Client) func(context.Context) error {
 	return func(ctx context.Context) error {
 		if err := vaultClient.TokenLookupSelf(); err != nil {
 			return err
@@ -71,12 +22,11 @@ func newCertificateeHealthChecker(vaultClient *vault.VaultClient, haproxyClients
 			}
 
 			if _, err := client.ListCertificateRefs(); err != nil {
+				if haproxy.IsV3UnavailableError(err) {
+					continue
+				}
 				errs = append(errs, fmt.Errorf("%s: %w", client.Endpoint(), err))
 			}
-		}
-
-		if err := state.Check(maxSyncAge); err != nil {
-			errs = append(errs, err)
 		}
 
 		return errors.Join(errs...)

--- a/cmd/certificatee/health.go
+++ b/cmd/certificatee/health.go
@@ -2,33 +2,18 @@ package main
 
 import (
 	"context"
-	"errors"
-	"fmt"
-
-	"github.com/vinted/certificator/pkg/haproxy"
 	"github.com/vinted/certificator/pkg/vault"
 )
 
-func newCertificateeHealthChecker(vaultClient *vault.VaultClient, haproxyClients []*haproxy.Client) func(context.Context) error {
+func newCertificateeHealthChecker(vaultClient *vault.VaultClient) func(context.Context) error {
 	return func(ctx context.Context) error {
-		if err := vaultClient.TokenLookupSelf(); err != nil {
+		if err := ctx.Err(); err != nil {
 			return err
 		}
 
-		var errs []error
-		for _, client := range haproxyClients {
-			if err := ctx.Err(); err != nil {
-				return err
-			}
-
-			if _, err := client.ListCertificateRefs(); err != nil {
-				if haproxy.IsV3UnavailableError(err) {
-					continue
-				}
-				errs = append(errs, fmt.Errorf("%s: %w", client.Endpoint(), err))
-			}
+		if err := vaultClient.TokenLookupSelf(); err != nil {
+			return err
 		}
-
-		return errors.Join(errs...)
+		return nil
 	}
 }

--- a/cmd/certificatee/main.go
+++ b/cmd/certificatee/main.go
@@ -93,22 +93,17 @@ func processHAProxyEndpoint(logger *logrus.Logger, cfg config.Config, vaultClien
 	certRefs, err := haproxyClient.ListCertificateRefs()
 	if err != nil {
 		if haproxy.IsV3UnavailableError(err) {
-			certmetrics.HAProxyEndpointUp.WithLabelValues(endpoint).Set(1)
-			certmetrics.HAProxyEndpointV3Ready.WithLabelValues(endpoint).Set(0)
-			certmetrics.HAProxyEndpointWorking.WithLabelValues(endpoint).Set(0)
+			setEndpointState(endpoint, 1, 0, 0)
 			logger.Infof("[%s] HAProxy Data Plane API v3 certificate storage endpoint not available yet, waiting for upgrade", endpoint)
 			return nil
 		}
 
-		certmetrics.HAProxyEndpointUp.WithLabelValues(endpoint).Set(0)
-		certmetrics.HAProxyEndpointV3Ready.WithLabelValues(endpoint).Set(0)
-		certmetrics.HAProxyEndpointWorking.WithLabelValues(endpoint).Set(0)
+		setEndpointState(endpoint, 0, 0, 0)
 		return fmt.Errorf("failed to list certificates: %w", err)
 	}
 
 	// Mark endpoint as up and record sync timestamp
-	certmetrics.HAProxyEndpointUp.WithLabelValues(endpoint).Set(1)
-	certmetrics.HAProxyEndpointV3Ready.WithLabelValues(endpoint).Set(1)
+	setEndpointState(endpoint, 1, 1, 0)
 	certmetrics.LastSyncTimestamp.WithLabelValues(endpoint).SetToCurrentTime()
 	certmetrics.CertificatesTotal.WithLabelValues(endpoint).Set(float64(len(certRefs)))
 
@@ -185,12 +180,18 @@ func processHAProxyEndpoint(logger *logrus.Logger, cfg config.Config, vaultClien
 	// Record expiring certificates count
 	certmetrics.CertificatesExpiring.WithLabelValues(endpoint).Set(float64(expiringCount))
 	if len(errs) == 0 {
-		certmetrics.HAProxyEndpointWorking.WithLabelValues(endpoint).Set(1)
+		setEndpointState(endpoint, 1, 1, 1)
 	} else {
-		certmetrics.HAProxyEndpointWorking.WithLabelValues(endpoint).Set(0)
+		setEndpointState(endpoint, 1, 1, 0)
 	}
 
 	return errors.Join(errs...)
+}
+
+func setEndpointState(endpoint string, reachable, v3Ready, working float64) {
+	certmetrics.HAProxyEndpointUp.WithLabelValues(endpoint, "reachable").Set(reachable)
+	certmetrics.HAProxyEndpointUp.WithLabelValues(endpoint, "v3_ready").Set(v3Ready)
+	certmetrics.HAProxyEndpointUp.WithLabelValues(endpoint, "working").Set(working)
 }
 
 func shouldUpdateCertificate(domain string, vaultClient *vault.VaultClient, haproxyCert *haproxy.CertificateDetail, renewBeforeDays int) (shouldUpdate bool, reason string, isExpiring bool, err error) {

--- a/cmd/certificatee/main.go
+++ b/cmd/certificatee/main.go
@@ -44,7 +44,7 @@ func main() {
 		logger.Fatal(err)
 	}
 
-	certmetrics.StartMetricsServer(logger, cfg.Metrics.ListenAddress, newCertificateeHealthChecker(vaultClient, haproxyClients))
+	certmetrics.StartMetricsServer(logger, cfg.Metrics.ListenAddress, newCertificateeHealthChecker(vaultClient))
 	defer certmetrics.PushMetrics(logger, cfg.Metrics.PushUrl)
 
 	logger.Infof("Configured %d HAProxy endpoint(s)", len(haproxyClients))

--- a/cmd/certificatee/main.go
+++ b/cmd/certificatee/main.go
@@ -44,8 +44,7 @@ func main() {
 		logger.Fatal(err)
 	}
 
-	healthState := &syncHealthState{}
-	certmetrics.StartMetricsServer(logger, cfg.Metrics.ListenAddress, newCertificateeHealthChecker(vaultClient, haproxyClients, healthState, cfg.Certificatee.UpdateInterval))
+	certmetrics.StartMetricsServer(logger, cfg.Metrics.ListenAddress, newCertificateeHealthChecker(vaultClient, haproxyClients))
 	defer certmetrics.PushMetrics(logger, cfg.Metrics.PushUrl)
 
 	logger.Infof("Configured %d HAProxy endpoint(s)", len(haproxyClients))
@@ -61,19 +60,13 @@ func main() {
 
 	// Initial run
 	if err := maybeUpdateCertificates(logger, cfg, vaultClient, haproxyClients); err != nil {
-		healthState.Mark(err)
 		logger.Error(err)
-	} else {
-		healthState.Mark(nil)
 	}
 
 	for range ticker.C {
 		if err := maybeUpdateCertificates(logger, cfg, vaultClient, haproxyClients); err != nil {
-			healthState.Mark(err)
 			logger.Error(err)
-			continue
 		}
-		healthState.Mark(nil)
 	}
 }
 
@@ -99,12 +92,23 @@ func processHAProxyEndpoint(logger *logrus.Logger, cfg config.Config, vaultClien
 	// Get list of certificates from HAProxy with file paths for lookups
 	certRefs, err := haproxyClient.ListCertificateRefs()
 	if err != nil {
+		if haproxy.IsV3UnavailableError(err) {
+			certmetrics.HAProxyEndpointUp.WithLabelValues(endpoint).Set(1)
+			certmetrics.HAProxyEndpointV3Ready.WithLabelValues(endpoint).Set(0)
+			certmetrics.HAProxyEndpointWorking.WithLabelValues(endpoint).Set(0)
+			logger.Infof("[%s] HAProxy Data Plane API v3 certificate storage endpoint not available yet, waiting for upgrade", endpoint)
+			return nil
+		}
+
 		certmetrics.HAProxyEndpointUp.WithLabelValues(endpoint).Set(0)
+		certmetrics.HAProxyEndpointV3Ready.WithLabelValues(endpoint).Set(0)
+		certmetrics.HAProxyEndpointWorking.WithLabelValues(endpoint).Set(0)
 		return fmt.Errorf("failed to list certificates: %w", err)
 	}
 
 	// Mark endpoint as up and record sync timestamp
 	certmetrics.HAProxyEndpointUp.WithLabelValues(endpoint).Set(1)
+	certmetrics.HAProxyEndpointV3Ready.WithLabelValues(endpoint).Set(1)
 	certmetrics.LastSyncTimestamp.WithLabelValues(endpoint).SetToCurrentTime()
 	certmetrics.CertificatesTotal.WithLabelValues(endpoint).Set(float64(len(certRefs)))
 
@@ -144,7 +148,7 @@ func processHAProxyEndpoint(logger *logrus.Logger, cfg config.Config, vaultClien
 			}
 		}
 
-		if !haproxyCert.NotAfter.IsZero() {
+		if haproxyCert != nil && !haproxyCert.NotAfter.IsZero() {
 			certmetrics.CertificateNotAfterTimestamp.WithLabelValues(endpoint, domain).Set(float64(haproxyCert.NotAfter.Unix()))
 		}
 
@@ -180,6 +184,11 @@ func processHAProxyEndpoint(logger *logrus.Logger, cfg config.Config, vaultClien
 
 	// Record expiring certificates count
 	certmetrics.CertificatesExpiring.WithLabelValues(endpoint).Set(float64(expiringCount))
+	if len(errs) == 0 {
+		certmetrics.HAProxyEndpointWorking.WithLabelValues(endpoint).Set(1)
+	} else {
+		certmetrics.HAProxyEndpointWorking.WithLabelValues(endpoint).Set(0)
+	}
 
 	return errors.Join(errs...)
 }

--- a/pkg/certmetrics/metrics.go
+++ b/pkg/certmetrics/metrics.go
@@ -71,6 +71,14 @@ var (
 		Name: "certificatee_haproxy_endpoint_up",
 		Help: "Indicates if HAProxy endpoint is reachable (1 = up, 0 = down)",
 	}, []string{"endpoint"})
+	HAProxyEndpointV3Ready = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "certificatee_haproxy_endpoint_v3_ready",
+		Help: "Indicates if HAProxy endpoint exposes the Data Plane API v3 certificate storage API (1 = ready, 0 = waiting)",
+	}, []string{"endpoint"})
+	HAProxyEndpointWorking = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "certificatee_haproxy_endpoint_working",
+		Help: "Indicates if certificatee is actively syncing certificates for the HAProxy endpoint (1 = working, 0 = not working)",
+	}, []string{"endpoint"})
 	LastSyncTimestamp = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "certificatee_last_sync_timestamp_seconds",
 		Help: "Unix timestamp of the last successful sync",

--- a/pkg/certmetrics/metrics.go
+++ b/pkg/certmetrics/metrics.go
@@ -69,16 +69,8 @@ var (
 	// HAProxy endpoint health
 	HAProxyEndpointUp = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "certificatee_haproxy_endpoint_up",
-		Help: "Indicates if HAProxy endpoint is reachable (1 = up, 0 = down)",
-	}, []string{"endpoint"})
-	HAProxyEndpointV3Ready = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "certificatee_haproxy_endpoint_v3_ready",
-		Help: "Indicates if HAProxy endpoint exposes the Data Plane API v3 certificate storage API (1 = ready, 0 = waiting)",
-	}, []string{"endpoint"})
-	HAProxyEndpointWorking = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "certificatee_haproxy_endpoint_working",
-		Help: "Indicates if certificatee is actively syncing certificates for the HAProxy endpoint (1 = working, 0 = not working)",
-	}, []string{"endpoint"})
+		Help: "Indicates HAProxy endpoint state for certificatee (1 = true, 0 = false)",
+	}, []string{"endpoint", "state"})
 	LastSyncTimestamp = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "certificatee_last_sync_timestamp_seconds",
 		Help: "Unix timestamp of the last successful sync",

--- a/pkg/haproxy/client.go
+++ b/pkg/haproxy/client.go
@@ -259,6 +259,13 @@ func (c *Client) ListCertificateRefs() ([]CertificateRef, error) {
 	return refs, nil
 }
 
+func IsV3UnavailableError(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(err.Error(), "path /v3/services/haproxy/storage/ssl_certificates was not found")
+}
+
 // GetCertificateDetail returns Data Plane API metadata for a specific
 // certificate file.
 func (c *Client) GetCertificateDetail(certName string) (*CertificateDetail, error) {


### PR DESCRIPTION
## Summary
- add a real /health endpoint alongside /metrics
- make certificatee tolerate mixed DPAPI v2/v3 rollout without failing Nomad health checks
- expose per-endpoint rollout state via certificatee_haproxy_endpoint_up{state=...}
- fix wildcard metadata fallback so missing per-cert detail does not panic

## Testing
- env GOCACHE=/tmp/go-build-certificator go test ./pkg/certmetrics ./cmd/certificatee ./cmd/certificator
- env GOCACHE=/tmp/go-build-certificator go test -run '^$' ./pkg/haproxy