### PR TITLE
Fix certificatee DPAPI v3 runtime cert handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A daemon that synchronizes certificates from Vault to HAProxy using the HAProxy 
 - The certificate is expiring within the configured threshold (default: 30 days)
 - The certificate serial number differs from the one stored in Vault
 
-During rollout, `certificatee` tolerates mixed HAProxy Data Plane API versions. If an endpoint is still on v2, unreachable, or unhealthy, `certificatee` itself stays healthy, reports the endpoint state via metrics, and starts syncing automatically once the v3 certificate storage API becomes available.
+`certificatee` requires HAProxy Data Plane API v3. It reads expiry and serial metadata from HAProxy's live runtime certificate state and uses Vault only as the source for replacement certificate payloads.
 
 ## Configuration
 
@@ -61,8 +61,8 @@ Certificatee uses the HAProxy Data Plane API to update certificates at runtime w
 - **Basic authentication**: Authenticate using username/password credentials
 - **Automatic retries**: Connections are retried with exponential backoff (default: 3 retries, 1-30s delays)
 - **Graceful degradation**: If one HAProxy instance is unreachable, the tool continues updating reachable instances
-- **REST API**: Certificates are managed via the HAProxy Data Plane API v3 `/v3/services/haproxy/storage/ssl_certificates` endpoints
-- **Mixed-version rollout tolerance**: v2-only endpoints are treated as waiting, not fatal, until the v3 certificate storage API is available
+- **REST API**: Certificates are managed via the HAProxy Data Plane API v3 `/v3/services/haproxy/runtime/ssl_certs` endpoints
+- **Live certificate state**: Expiry checks use HAProxy's currently loaded certificate metadata, not Vault certificate expiry
 
 ### HAProxy Data Plane API Configuration
 
@@ -90,7 +90,7 @@ Certificate files must be named after the domain (e.g., `/etc/haproxy/certs/exam
 Certificatee exposes Prometheus metrics for monitoring:
 
 - `GET /metrics` exposes Prometheus metrics.
-- `GET /health` returns `200 OK` when the process can still reach Vault. HAProxy Data Plane API reachability and rollout state are reported via metrics and do not make the process unhealthy in Nomad.
+- `GET /health` returns `200 OK` when the process can still reach Vault. HAProxy Data Plane API failures are reported via metrics and logs.
 
 ### General Metrics
 
@@ -104,9 +104,9 @@ Certificatee exposes Prometheus metrics for monitoring:
 
 | Metric | Type | Labels | Description |
 |--------|------|--------|-------------|
-| `certificatee_haproxy_endpoint_up` | Gauge | endpoint, state | Endpoint rollout state. `state="reachable"` means the DPAPI endpoint is reachable, `state="v3_ready"` means the v3 certificate storage API is available, and `state="working"` means certificatee is actively syncing that endpoint |
-| `certificatee_certificate_not_after_timestamp_seconds` | Gauge | endpoint, domain | Certificate expiry reported by the HAProxy Data Plane API |
-| `certificatee_certificate_metadata_lookup_failures_total` | Counter | endpoint, domain | Per-certificate DPAPI metadata lookups that failed and fell back to Vault-only expiry checks |
+| `certificatee_haproxy_endpoint_up` | Gauge | endpoint, state | Endpoint state. `state="reachable"` and `state="v3_ready"` mean the v3 runtime API is available, and `state="working"` means certificatee processed the endpoint without certificate errors |
+| `certificatee_certificate_not_after_timestamp_seconds` | Gauge | endpoint, domain | Live certificate expiry reported by the HAProxy Data Plane API runtime endpoint |
+| `certificatee_certificate_metadata_lookup_failures_total` | Counter | endpoint, domain | Per-certificate DPAPI runtime metadata lookups that failed |
 | `certificatee_haproxy_connections_total` | Counter | endpoint, status | Total connection attempts (status: success/failure) |
 | `certificatee_haproxy_connection_retries_total` | Counter | endpoint | Connection retry attempts |
 | `certificatee_haproxy_certificates_checked_total` | Counter | endpoint | Certificates checked per endpoint |

--- a/cmd/certificatee/main.go
+++ b/cmd/certificatee/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"crypto/x509"
 	"errors"
 	"fmt"
 	"strings"
@@ -89,17 +90,10 @@ func maybeUpdateCertificates(logger *logrus.Logger, cfg config.Config, vaultClie
 func processHAProxyEndpoint(logger *logrus.Logger, cfg config.Config, vaultClient *vault.VaultClient, haproxyClient *haproxy.Client) error {
 	endpoint := haproxyClient.Endpoint()
 
-	// Get list of certificates from HAProxy with file paths for lookups
 	certRefs, err := haproxyClient.ListCertificateRefs()
 	if err != nil {
-		if haproxy.IsV3UnavailableError(err) {
-			setEndpointState(endpoint, 1, 0, 0)
-			logger.Infof("[%s] HAProxy Data Plane API v3 certificate storage endpoint not available yet, waiting for upgrade", endpoint)
-			return nil
-		}
-
 		setEndpointState(endpoint, 0, 0, 0)
-		return fmt.Errorf("failed to list certificates: %w", err)
+		return fmt.Errorf("failed to list live certificates: %w", err)
 	}
 
 	// Mark endpoint as up and record sync timestamp
@@ -109,7 +103,7 @@ func processHAProxyEndpoint(logger *logrus.Logger, cfg config.Config, vaultClien
 
 	var wildcardCount int
 	for _, ref := range certRefs {
-		if strings.Contains(ref.DisplayName, "*") || strings.Contains(ref.FilePath, "*") {
+		if strings.Contains(ref.DisplayName, "*") || strings.Contains(ref.APIName, "*") {
 			wildcardCount++
 		}
 	}
@@ -121,34 +115,29 @@ func processHAProxyEndpoint(logger *logrus.Logger, cfg config.Config, vaultClien
 	var expiringCount int
 
 	for _, ref := range certRefs {
-		certPath := ref.DisplayName
-		logger.Infof("[%s] Checking certificate: %s", endpoint, certPath)
+		displayName := ref.DisplayName
+		apiName := ref.APIName
+		logger.Infof("[%s] Checking certificate: %s", endpoint, displayName)
 
 		// Extract domain name from certificate path and normalize _.domain → *.domain for Vault
-		rawDomain := haproxy.ExtractDomainFromPath(certPath)
+		rawDomain := haproxy.ExtractDomainFromPath(displayName)
 		domain := haproxy.NormalizeDomainForVault(rawDomain)
-		logger.Debugf("[%s] Extracted domain '%s' from path '%s'", endpoint, domain, certPath)
+		logger.Debugf("[%s] Extracted domain '%s' from certificate '%s'", endpoint, domain, displayName)
 
-		haproxyCert, err := haproxyClient.GetCertificateDetail(certPath)
+		haproxyCert, err := haproxyClient.GetCertificateDetail(apiName)
 		if err != nil {
 			certmetrics.CertificateMetadataLookupFailures.WithLabelValues(endpoint, domain).Inc()
-
-			if strings.Contains(err.Error(), "status 404") {
-				logger.Warnf("[%s] missing dataplane metadata for %s, falling back to vault expiry only: %v", endpoint, certPath, err)
-				haproxyCert = nil
-			} else {
-				errs = append(errs, err)
-				logger.Errorf("[%s] failed to get dataplane metadata for %s: %v", endpoint, certPath, err)
-				continue
-			}
+			errs = append(errs, err)
+			logger.Errorf("[%s] failed to get live dataplane metadata for %s: %v", endpoint, displayName, err)
+			continue
 		}
 
 		if haproxyCert != nil && !haproxyCert.NotAfter.IsZero() {
 			certmetrics.CertificateNotAfterTimestamp.WithLabelValues(endpoint, domain).Set(float64(haproxyCert.NotAfter.Unix()))
 		}
 
-		// Use Vault as the source of truth and HAProxy Data Plane API v3 metadata as
-		// the source of the currently loaded certificate state.
+		// Use HAProxy's live certificate metadata for expiry. Vault provides the
+		// replacement payload and serial used to detect a newer issued certificate.
 		shouldUpdate, reason, isExpiring, err := shouldUpdateCertificate(domain, vaultClient, haproxyCert, cfg.Certificatee.RenewBeforeDays)
 		if err != nil {
 			errs = append(errs, err)
@@ -162,18 +151,18 @@ func processHAProxyEndpoint(logger *logrus.Logger, cfg config.Config, vaultClien
 		}
 
 		if shouldUpdate {
-			logger.Infof("[%s] Certificate %s needs update: %s", endpoint, certPath, reason)
+			logger.Infof("[%s] Certificate %s needs update: %s", endpoint, displayName, reason)
 
-			if err := updateCertificate(certPath, domain, vaultClient, haproxyClient); err != nil {
+			if err := updateCertificate(apiName, domain, vaultClient, haproxyClient); err != nil {
 				errs = append(errs, err)
 				logger.Errorf("[%s] %v", endpoint, err)
 				certmetrics.CertificatesUpdateFailures.WithLabelValues(endpoint, domain).Inc()
 			} else {
 				certmetrics.CertificatesUpdated.WithLabelValues(endpoint, domain).Inc()
-				logger.Infof("[%s] Certificate %s updated successfully!", endpoint, certPath)
+				logger.Infof("[%s] Certificate %s updated successfully!", endpoint, displayName)
 			}
 		} else {
-			logger.Infof("[%s] Certificate %s is up to date", endpoint, certPath)
+			logger.Infof("[%s] Certificate %s is up to date", endpoint, displayName)
 		}
 	}
 
@@ -195,6 +184,11 @@ func setEndpointState(endpoint string, reachable, v3Ready, working float64) {
 }
 
 func shouldUpdateCertificate(domain string, vaultClient *vault.VaultClient, haproxyCert *haproxy.CertificateDetail, renewBeforeDays int) (shouldUpdate bool, reason string, isExpiring bool, err error) {
+	shouldUpdate, reason, isExpiring, err = shouldUpdateForLiveExpiry(domain, haproxyCert, renewBeforeDays)
+	if err != nil || shouldUpdate {
+		return shouldUpdate, reason, isExpiring, err
+	}
+
 	vaultCert, err := certificate.GetCertificate(domain, vaultClient)
 	if err != nil {
 		return false, "", false, fmt.Errorf("failed to get certificate %s from vault: %w", domain, err)
@@ -204,37 +198,36 @@ func shouldUpdateCertificate(domain string, vaultClient *vault.VaultClient, hapr
 		return false, "", false, fmt.Errorf("certificate for %s does not exist in vault", domain)
 	}
 
+	shouldUpdate, reason = shouldUpdateForSerialMismatch(vaultCert, haproxyCert)
+	return shouldUpdate, reason, false, nil
+}
+
+func shouldUpdateForLiveExpiry(domain string, haproxyCert *haproxy.CertificateDetail, renewBeforeDays int) (shouldUpdate bool, reason string, isExpiring bool, err error) {
 	if haproxyCert == nil {
-		threshold := time.Now().AddDate(0, 0, renewBeforeDays)
-		isExpiring = vaultCert.NotAfter.Before(threshold)
-		if isExpiring {
-			return true, fmt.Sprintf("vault certificate expires on %s (haproxy metadata unavailable)", vaultCert.NotAfter.Format(time.RFC3339)), true, nil
-		}
-		return false, "", false, nil
+		return false, "", false, fmt.Errorf("live certificate metadata for %s is unavailable", domain)
 	}
 
 	if haproxyCert.NotAfter.IsZero() {
-		return false, "", false, fmt.Errorf("certificate %s is missing not_after in haproxy metadata", domain)
+		return false, "", false, fmt.Errorf("certificate %s is missing not_after in live haproxy metadata", domain)
 	}
 
 	threshold := time.Now().AddDate(0, 0, renewBeforeDays)
 	isExpiring = haproxyCert.NotAfter.Before(threshold)
-
 	if isExpiring {
-		return true, fmt.Sprintf("haproxy certificate expires on %s (within %d days)", haproxyCert.NotAfter.Format(time.RFC3339), renewBeforeDays), true, nil
-	}
-
-	vaultSerial := haproxy.NormalizeSerial(vaultCert.SerialNumber.Text(16))
-	haproxySerial := haproxy.NormalizeSerial(haproxyCert.Serial)
-	if haproxySerial != "" && vaultSerial != haproxySerial {
-		return true, fmt.Sprintf("serial mismatch: vault=%s haproxy=%s", vaultSerial, haproxySerial), false, nil
-	}
-
-	if vaultCert.NotAfter.After(haproxyCert.NotAfter) {
-		return true, fmt.Sprintf("vault certificate is newer: vault=%s haproxy=%s", vaultCert.NotAfter.Format(time.RFC3339), haproxyCert.NotAfter.Format(time.RFC3339)), false, nil
+		return true, fmt.Sprintf("live haproxy certificate expires on %s (within %d days)", haproxyCert.NotAfter.Format(time.RFC3339), renewBeforeDays), true, nil
 	}
 
 	return false, "", false, nil
+}
+
+func shouldUpdateForSerialMismatch(vaultCert *x509.Certificate, haproxyCert *haproxy.CertificateDetail) (bool, string) {
+	vaultSerial := haproxy.NormalizeSerial(vaultCert.SerialNumber.Text(16))
+	haproxySerial := haproxy.NormalizeSerial(haproxyCert.Serial)
+	if haproxySerial != "" && vaultSerial != haproxySerial {
+		return true, fmt.Sprintf("serial mismatch: vault=%s haproxy=%s", vaultSerial, haproxySerial)
+	}
+
+	return false, ""
 }
 
 func updateCertificate(certPath, domain string, vaultClient *vault.VaultClient, haproxyClient *haproxy.Client) error {

--- a/cmd/certificatee/main_test.go
+++ b/cmd/certificatee/main_test.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"crypto/x509"
+	"math/big"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vinted/certificator/pkg/haproxy"
+)
+
+func TestShouldUpdateForLiveExpiry(t *testing.T) {
+	t.Run("requires live metadata", func(t *testing.T) {
+		_, _, _, err := shouldUpdateForLiveExpiry("example.com", nil, 30)
+		if err == nil || !strings.Contains(err.Error(), "live certificate metadata") {
+			t.Fatalf("expected live metadata error, got %v", err)
+		}
+	})
+
+	t.Run("requires live not_after", func(t *testing.T) {
+		_, _, _, err := shouldUpdateForLiveExpiry("example.com", &haproxy.CertificateDetail{}, 30)
+		if err == nil || !strings.Contains(err.Error(), "missing not_after") {
+			t.Fatalf("expected missing not_after error, got %v", err)
+		}
+	})
+
+	t.Run("uses live expiry inside threshold", func(t *testing.T) {
+		liveCert := &haproxy.CertificateDetail{
+			NotAfter: time.Now().AddDate(0, 0, 10),
+		}
+
+		shouldUpdate, reason, isExpiring, err := shouldUpdateForLiveExpiry("example.com", liveCert, 30)
+		if err != nil {
+			t.Fatalf("shouldUpdateForLiveExpiry() error = %v", err)
+		}
+		if !shouldUpdate || !isExpiring {
+			t.Fatalf("shouldUpdate=%v isExpiring=%v, want both true", shouldUpdate, isExpiring)
+		}
+		if !strings.Contains(reason, "live haproxy certificate expires") {
+			t.Fatalf("reason = %q, want live haproxy expiry", reason)
+		}
+	})
+
+	t.Run("does not update when live expiry is outside threshold", func(t *testing.T) {
+		liveCert := &haproxy.CertificateDetail{
+			NotAfter: time.Now().AddDate(0, 0, 60),
+		}
+
+		shouldUpdate, reason, isExpiring, err := shouldUpdateForLiveExpiry("example.com", liveCert, 30)
+		if err != nil {
+			t.Fatalf("shouldUpdateForLiveExpiry() error = %v", err)
+		}
+		if shouldUpdate || isExpiring || reason != "" {
+			t.Fatalf("shouldUpdate=%v isExpiring=%v reason=%q, want no update", shouldUpdate, isExpiring, reason)
+		}
+	})
+}
+
+func TestShouldUpdateForSerialMismatch(t *testing.T) {
+	vaultCert := &x509.Certificate{SerialNumber: big.NewInt(0x1f5202e0)}
+
+	t.Run("detects mismatch", func(t *testing.T) {
+		shouldUpdate, reason := shouldUpdateForSerialMismatch(vaultCert, &haproxy.CertificateDetail{Serial: "aa:bb"})
+		if !shouldUpdate {
+			t.Fatal("expected update for serial mismatch")
+		}
+		if !strings.Contains(reason, "serial mismatch") {
+			t.Fatalf("reason = %q, want serial mismatch", reason)
+		}
+	})
+
+	t.Run("normalizes matching serials", func(t *testing.T) {
+		shouldUpdate, reason := shouldUpdateForSerialMismatch(vaultCert, &haproxy.CertificateDetail{Serial: "1F:52:02:E0"})
+		if shouldUpdate || reason != "" {
+			t.Fatalf("shouldUpdate=%v reason=%q, want no update", shouldUpdate, reason)
+		}
+	})
+}

--- a/pkg/haproxy/client.go
+++ b/pkg/haproxy/client.go
@@ -168,7 +168,7 @@ func (c *Client) getConfigVersion() (string, error) {
 	return version, nil
 }
 
-// SSLCertificateEntry represents an SSL certificate entry from storage API
+// SSLCertificateEntry represents an SSL certificate entry from the Data Plane API.
 type SSLCertificateEntry struct {
 	File        string `json:"file"`
 	StorageName string `json:"storage_name"`
@@ -199,12 +199,12 @@ type CertificateDetail struct {
 	Serial      string
 }
 
-// CertificateRef holds both display name and file path for a certificate
+// CertificateRef holds both display and runtime API names for a certificate.
 type CertificateRef struct {
-	// DisplayName is the storage_name or filename for display purposes
+	// DisplayName is the filename used for logs and Vault domain extraction.
 	DisplayName string
-	// FilePath is the full file path used for API lookups
-	FilePath string
+	// APIName is the DPAPI runtime ssl_certs name used for detail and update calls.
+	APIName string
 }
 
 // ListCertificates returns a list of certificates from HAProxy Data Plane API
@@ -221,10 +221,9 @@ func (c *Client) ListCertificates() ([]string, error) {
 	return certNames, nil
 }
 
-// ListCertificateRefs returns a list of certificate references with both display names and file paths
+// ListCertificateRefs returns the certificates currently loaded by HAProxy.
 func (c *Client) ListCertificateRefs() ([]CertificateRef, error) {
-	// Use storage API endpoint for listing SSL certificates
-	resp, err := c.doRequest("GET", "/v3/services/haproxy/storage/ssl_certificates", nil, "")
+	resp, err := c.doRequest("GET", "/v3/services/haproxy/runtime/ssl_certs", nil, "")
 	if err != nil {
 		return nil, err
 	}
@@ -232,7 +231,7 @@ func (c *Client) ListCertificateRefs() ([]CertificateRef, error) {
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
-		return nil, errors.Errorf("failed to list certificates: status %d, body: %s", resp.StatusCode, string(body))
+		return nil, errors.Errorf("failed to list live certificates: status %d, body: %s", resp.StatusCode, string(body))
 	}
 
 	var certs []SSLCertificateEntry
@@ -242,34 +241,31 @@ func (c *Client) ListCertificateRefs() ([]CertificateRef, error) {
 
 	var refs []CertificateRef
 	for _, cert := range certs {
-		ref := CertificateRef{
-			FilePath: cert.File,
+		apiName := cert.StorageName
+		if apiName == "" {
+			apiName = cert.File
 		}
-		// Prefer storage_name for display, fall back to file path
-		if cert.StorageName != "" {
-			ref.DisplayName = cert.StorageName
-		} else if cert.File != "" {
-			ref.DisplayName = cert.File
+
+		displayName := cert.Description
+		if displayName == "" {
+			displayName = apiName
 		}
-		if ref.DisplayName != "" || ref.FilePath != "" {
-			refs = append(refs, ref)
+
+		if apiName != "" && displayName != "" {
+			refs = append(refs, CertificateRef{
+				DisplayName: displayName,
+				APIName:     apiName,
+			})
 		}
 	}
 
 	return refs, nil
 }
 
-func IsV3UnavailableError(err error) bool {
-	if err == nil {
-		return false
-	}
-	return strings.Contains(err.Error(), "path /v3/services/haproxy/storage/ssl_certificates was not found")
-}
-
-// GetCertificateDetail returns Data Plane API metadata for a specific
-// certificate file.
+// GetCertificateDetail returns live HAProxy certificate metadata from the
+// Data Plane API v3 runtime endpoint.
 func (c *Client) GetCertificateDetail(certName string) (*CertificateDetail, error) {
-	path := fmt.Sprintf("/v3/services/haproxy/storage/ssl_certificates/%s", url.PathEscape(certName))
+	path := fmt.Sprintf("/v3/services/haproxy/runtime/ssl_certs/%s", url.PathEscape(certName))
 	resp, err := c.doRequest("GET", path, nil, "")
 	if err != nil {
 		return nil, err
@@ -308,16 +304,25 @@ func (c *Client) GetCertificateDetail(certName string) (*CertificateDetail, erro
 	}, nil
 }
 
-// UpdateCertificate uploads and commits a certificate update via Data Plane API
+// UpdateCertificate uploads a replacement certificate to the live HAProxy
+// runtime via Data Plane API v3.
 func (c *Client) UpdateCertificate(certName, pemData string) error {
-	version, err := c.getConfigVersion()
+	var buf bytes.Buffer
+	writer := multipart.NewWriter(&buf)
+
+	part, err := writer.CreateFormFile("file_upload", certName)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "failed to create form file")
+	}
+	if _, err := part.Write([]byte(pemData)); err != nil {
+		return errors.Wrap(err, "failed to write certificate data")
+	}
+	if err := writer.Close(); err != nil {
+		return errors.Wrap(err, "failed to close multipart writer")
 	}
 
-	// Send PUT request to replace certificate
-	path := fmt.Sprintf("/v3/services/haproxy/storage/ssl_certificates/%s?version=%s", url.PathEscape(certName), url.QueryEscape(version))
-	resp, err := c.doRequest("PUT", path, strings.NewReader(pemData), "text/plain")
+	path := fmt.Sprintf("/v3/services/haproxy/runtime/ssl_certs/%s", url.PathEscape(certName))
+	resp, err := c.doRequest("PUT", path, &buf, writer.FormDataContentType())
 	if err != nil {
 		return err
 	}

--- a/pkg/haproxy/client_test.go
+++ b/pkg/haproxy/client_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -322,7 +323,7 @@ func newMockDataPlaneAPI(t *testing.T) *mockDataPlaneAPI {
 			return
 		}
 
-		// Try prefix matching for dynamic paths (e.g., /v3/services/haproxy/storage/ssl_certificates/example.com.pem)
+		// Try prefix matching for dynamic paths (e.g., /v3/services/haproxy/runtime/ssl_certs/example.com.pem)
 		for pattern, handler := range m.handlers {
 			if strings.HasPrefix(key, pattern) {
 				handler(w, r)
@@ -370,8 +371,8 @@ func TestListCertificates(t *testing.T) {
 		{
 			name: "normal response with multiple certs",
 			response: []SSLCertificateEntry{
-				{File: "/etc/haproxy/certs/site1.pem", StorageName: "site1.pem"},
-				{File: "/etc/haproxy/certs/site2.pem", StorageName: "site2.pem"},
+				{Description: "site1.pem", StorageName: "certs/site1.pem"},
+				{Description: "site2.pem", StorageName: "certs/site2.pem"},
 			},
 			statusCode: http.StatusOK,
 			want:       []string{"site1.pem", "site2.pem"},
@@ -385,19 +386,19 @@ func TestListCertificates(t *testing.T) {
 			wantErr:    false,
 		},
 		{
-			name: "certs with storage_name",
+			name: "certs without description fall back to runtime name",
 			response: []SSLCertificateEntry{
-				{StorageName: "example.com.pem"},
-				{StorageName: "test.com.pem"},
+				{StorageName: "certs/example.com.pem"},
+				{StorageName: "certs/test.com.pem"},
 			},
 			statusCode: http.StatusOK,
-			want:       []string{"example.com.pem", "test.com.pem"},
+			want:       []string{"certs/example.com.pem", "certs/test.com.pem"},
 			wantErr:    false,
 		},
 		{
 			name: "single certificate",
 			response: []SSLCertificateEntry{
-				{File: "/etc/haproxy/certs/only.pem", StorageName: "only.pem"},
+				{Description: "only.pem", StorageName: "certs/only.pem"},
 			},
 			statusCode: http.StatusOK,
 			want:       []string{"only.pem"},
@@ -416,7 +417,7 @@ func TestListCertificates(t *testing.T) {
 			mock := newMockDataPlaneAPI(t)
 			defer mock.Close()
 
-			mock.SetHandler("GET", "/v3/services/haproxy/storage/ssl_certificates", func(w http.ResponseWriter, r *http.Request) {
+			mock.SetHandler("GET", "/v3/services/haproxy/runtime/ssl_certs", func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(tt.statusCode)
 				if tt.response != nil {
@@ -463,14 +464,14 @@ func TestUpdateCertificate(t *testing.T) {
 	}{
 		{
 			name:       "success - certificate updated",
-			certName:   "example.com.pem",
+			certName:   "certs/example.com.pem",
 			pemData:    "-----BEGIN CERTIFICATE-----\ntest\n-----END CERTIFICATE-----",
 			statusCode: http.StatusOK,
 			wantErr:    false,
 		},
 		{
 			name:       "success - accepted",
-			certName:   "example.com.pem",
+			certName:   "certs/example.com.pem",
 			pemData:    "-----BEGIN CERTIFICATE-----\ntest\n-----END CERTIFICATE-----",
 			statusCode: http.StatusAccepted,
 			wantErr:    false,
@@ -496,27 +497,32 @@ func TestUpdateCertificate(t *testing.T) {
 			mock := newMockDataPlaneAPI(t)
 			defer mock.Close()
 
-			mock.SetHandler("GET", "/v3/services/haproxy/configuration/version", func(w http.ResponseWriter, r *http.Request) {
-				_, _ = w.Write([]byte("42"))
-			})
-
-			mock.SetHandler("PUT", "/v3/services/haproxy/storage/ssl_certificates/"+tt.certName, func(w http.ResponseWriter, r *http.Request) {
-				if r.URL.Query().Get("version") != "42" {
-					t.Errorf("version query = %q, want %q", r.URL.Query().Get("version"), "42")
+			mock.SetHandler("PUT", "/v3/services/haproxy/runtime/ssl_certs/", func(w http.ResponseWriter, r *http.Request) {
+				if tt.certName == "certs/example.com.pem" && !strings.Contains(r.URL.EscapedPath(), "certs%2Fexample.com.pem") {
+					t.Errorf("escaped path = %q, want encoded runtime cert name", r.URL.EscapedPath())
 				}
 
-				// Verify content type is plain text
 				contentType := r.Header.Get("Content-Type")
-				if !strings.Contains(contentType, "text/plain") {
-					t.Errorf("Expected text/plain content type, got %s", contentType)
+				if !strings.Contains(contentType, "multipart/form-data") {
+					t.Errorf("Expected multipart/form-data content type, got %s", contentType)
 				}
 
-				data, err := io.ReadAll(r.Body)
-				if err != nil {
-					t.Errorf("Failed to read request body: %v", err)
+				if err := r.ParseMultipartForm(10 << 20); err != nil {
+					t.Errorf("Failed to parse multipart form: %v", err)
 				}
-				if string(data) != tt.pemData {
-					t.Errorf("File data = %q, want %q", string(data), tt.pemData)
+				file, header, err := r.FormFile("file_upload")
+				if err != nil {
+					t.Errorf("Failed to get file from form: %v", err)
+				} else {
+					defer func() { _ = file.Close() }()
+					expectedFilename := filepath.Base(tt.certName)
+					if header.Filename != expectedFilename {
+						t.Errorf("Filename = %q, want %q", header.Filename, expectedFilename)
+					}
+					data, _ := io.ReadAll(file)
+					if string(data) != tt.pemData {
+						t.Errorf("File data = %q, want %q", string(data), tt.pemData)
+					}
 				}
 
 				w.WriteHeader(tt.statusCode)
@@ -542,11 +548,10 @@ func TestGetCertificateDetail(t *testing.T) {
 	mock := newMockDataPlaneAPI(t)
 	defer mock.Close()
 
-	mock.SetHandler("GET", "/v3/services/haproxy/storage/ssl_certificates/example.com.pem", func(w http.ResponseWriter, r *http.Request) {
+	mock.SetHandler("GET", "/v3/services/haproxy/runtime/ssl_certs/certs/example.com.pem", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(map[string]any{
-			"file":         "/etc/haproxy/ssl/example.com.pem",
-			"storage_name": "example.com.pem",
+			"storage_name": "certs/example.com.pem",
 			"description":  "managed SSL file",
 			"domains":      "example.com",
 			"issuers":      "Example CA",
@@ -561,13 +566,13 @@ func TestGetCertificateDetail(t *testing.T) {
 		t.Fatalf("NewClient() error = %v", err)
 	}
 
-	detail, err := client.GetCertificateDetail("example.com.pem")
+	detail, err := client.GetCertificateDetail("certs/example.com.pem")
 	if err != nil {
 		t.Fatalf("GetCertificateDetail() error = %v", err)
 	}
 
-	if detail.StorageName != "example.com.pem" {
-		t.Errorf("StorageName = %q, want %q", detail.StorageName, "example.com.pem")
+	if detail.StorageName != "certs/example.com.pem" {
+		t.Errorf("StorageName = %q, want %q", detail.StorageName, "certs/example.com.pem")
 	}
 	if detail.Domains != "example.com" {
 		t.Errorf("Domains = %q, want %q", detail.Domains, "example.com")
@@ -751,7 +756,7 @@ func TestBasicAuth(t *testing.T) {
 	defer mock.Close()
 	mock.SetAuth("admin", "secret")
 
-	mock.SetHandler("GET", "/v3/services/haproxy/storage/ssl_certificates", func(w http.ResponseWriter, r *http.Request) {
+	mock.SetHandler("GET", "/v3/services/haproxy/runtime/ssl_certs", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		_ = json.NewEncoder(w).Encode([]SSLCertificateEntry{})


### PR DESCRIPTION
## Summary
- require certificatee to use HAProxy Data Plane API v3 runtime ssl_certs list/detail/update paths
- use HAProxy live runtime certificate metadata for renewal expiry decisions instead of Vault certificate expiry
- keep Vault as the replacement PEM source and use Vault serials only to detect newer issued certificates
- update README guidance and add unit coverage for live-expiry and runtime API behavior

## Testing
- env GOCACHE=/tmp/go-build-cache GOMODCACHE=/tmp/go-mod-cache go test ./...
- git diff --check