### PR TITLE
Fix certificatee DPAPI v3 readiness

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Certificate files must be named after the domain (e.g., `/etc/haproxy/certs/exam
 Certificatee exposes Prometheus metrics for monitoring:
 
 - `GET /metrics` exposes Prometheus metrics.
-- `GET /health` returns `200 OK` when the process can still reach Vault. HAProxy Data Plane API failures are reported via metrics and logs.
+- `GET /health` returns `200 OK` when the process can still reach Vault and at least one HAProxy Data Plane API endpoint has completed a recent v3 runtime certificate sync probe. Non-v3 endpoints are skipped and reported via metrics and logs.
 
 ### General Metrics
 
@@ -104,7 +104,7 @@ Certificatee exposes Prometheus metrics for monitoring:
 
 | Metric | Type | Labels | Description |
 |--------|------|--------|-------------|
-| `certificatee_haproxy_endpoint_up` | Gauge | endpoint, state | Endpoint state. `state="reachable"` and `state="v3_ready"` mean the v3 runtime API is available, and `state="working"` means certificatee processed the endpoint without certificate errors |
+| `certificatee_haproxy_endpoint_up` | Gauge | endpoint, state | Endpoint state. `state="reachable"` and `state="v3_ready"` mean the v3 runtime API is available, `state="v3_unsupported"` means the endpoint did not expose the v3 runtime certificate API on the last run, and `state="working"` means certificatee processed the endpoint without certificate errors |
 | `certificatee_certificate_not_after_timestamp_seconds` | Gauge | endpoint, domain | Live certificate expiry reported by the HAProxy Data Plane API runtime endpoint |
 | `certificatee_certificate_metadata_lookup_failures_total` | Counter | endpoint, domain | Per-certificate DPAPI runtime metadata lookups that failed |
 | `certificatee_haproxy_connections_total` | Counter | endpoint, status | Total connection attempts (status: success/failure) |

--- a/cmd/certificatee/health.go
+++ b/cmd/certificatee/health.go
@@ -2,19 +2,91 @@ package main
 
 import (
 	"context"
-
-	"github.com/vinted/certificator/pkg/vault"
+	"fmt"
+	"sync"
+	"time"
 )
 
-func newCertificateeHealthChecker(vaultClient *vault.VaultClient) func(context.Context) error {
-	return func(ctx context.Context) error {
-		if err := ctx.Err(); err != nil {
-			return err
-		}
+const certificateeHealthStartupGrace = 2 * time.Minute
 
-		if err := vaultClient.TokenLookupSelf(); err != nil {
-			return err
-		}
+type vaultTokenChecker interface {
+	TokenLookupSelf() error
+}
+
+type certificateeHealthChecker struct {
+	vaultClient  vaultTokenChecker
+	now          func() time.Time
+	startedAt    time.Time
+	startupGrace time.Duration
+	maxSyncAge   time.Duration
+
+	mu                 sync.RWMutex
+	lastSuccessfulSync time.Time
+}
+
+func newCertificateeHealthChecker(vaultClient vaultTokenChecker, updateInterval time.Duration) *certificateeHealthChecker {
+	now := time.Now
+	return &certificateeHealthChecker{
+		vaultClient:  vaultClient,
+		now:          now,
+		startedAt:    now(),
+		startupGrace: certificateeHealthStartupGrace,
+		maxSyncAge:   certificateeHealthMaxSyncAge(updateInterval),
+	}
+}
+
+func certificateeHealthMaxSyncAge(updateInterval time.Duration) time.Duration {
+	maxAge := updateInterval*2 + time.Minute
+	if maxAge < certificateeHealthStartupGrace {
+		return certificateeHealthStartupGrace
+	}
+	return maxAge
+}
+
+func (h *certificateeHealthChecker) Check(ctx context.Context) error {
+	if h == nil {
 		return nil
 	}
+
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	if h.vaultClient != nil {
+		if err := h.vaultClient.TokenLookupSelf(); err != nil {
+			return err
+		}
+	}
+
+	now := h.now()
+	lastSuccessfulSync := h.lastSync()
+	if !lastSuccessfulSync.IsZero() {
+		if now.Sub(lastSuccessfulSync) <= h.maxSyncAge {
+			return nil
+		}
+
+		return fmt.Errorf("no HAProxy Data Plane API v3 endpoint has completed a successful runtime certificate API probe since %s", lastSuccessfulSync.Format(time.RFC3339))
+	}
+
+	if now.Sub(h.startedAt) <= h.startupGrace {
+		return nil
+	}
+
+	return fmt.Errorf("no HAProxy Data Plane API v3 endpoint has completed a successful runtime certificate API probe")
+}
+
+func (h *certificateeHealthChecker) MarkEndpointSyncSuccess() {
+	if h == nil {
+		return
+	}
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.lastSuccessfulSync = h.now()
+}
+
+func (h *certificateeHealthChecker) lastSync() time.Time {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	return h.lastSuccessfulSync
 }

--- a/cmd/certificatee/health_test.go
+++ b/cmd/certificatee/health_test.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+type fakeVaultTokenChecker struct {
+	err error
+}
+
+func (f fakeVaultTokenChecker) TokenLookupSelf() error {
+	return f.err
+}
+
+func TestCertificateeHealthCheckerRequiresRecentEndpointSync(t *testing.T) {
+	start := time.Date(2026, 6, 12, 9, 0, 0, 0, time.UTC)
+	now := start
+
+	healthChecker := newCertificateeHealthChecker(fakeVaultTokenChecker{}, time.Minute)
+	healthChecker.now = func() time.Time { return now }
+	healthChecker.startedAt = start
+	healthChecker.startupGrace = time.Second
+	healthChecker.maxSyncAge = 2 * time.Second
+
+	if err := healthChecker.Check(context.Background()); err != nil {
+		t.Fatalf("Check() during startup grace error = %v, want nil", err)
+	}
+
+	now = start.Add(1500 * time.Millisecond)
+	err := healthChecker.Check(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "no HAProxy Data Plane API v3 endpoint") {
+		t.Fatalf("Check() after startup grace error = %v, want missing v3 endpoint sync", err)
+	}
+
+	healthChecker.MarkEndpointSyncSuccess()
+	if err := healthChecker.Check(context.Background()); err != nil {
+		t.Fatalf("Check() after sync success error = %v, want nil", err)
+	}
+
+	now = now.Add(3 * time.Second)
+	err = healthChecker.Check(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "no HAProxy Data Plane API v3 endpoint") {
+		t.Fatalf("Check() after stale sync error = %v, want stale v3 endpoint sync", err)
+	}
+}
+
+func TestCertificateeHealthCheckerChecksVault(t *testing.T) {
+	healthChecker := newCertificateeHealthChecker(fakeVaultTokenChecker{err: errors.New("vault unavailable")}, time.Minute)
+
+	err := healthChecker.Check(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "vault unavailable") {
+		t.Fatalf("Check() error = %v, want vault unavailable", err)
+	}
+}

--- a/cmd/certificatee/main.go
+++ b/cmd/certificatee/main.go
@@ -4,6 +4,7 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
+	"net/http"
 	"strings"
 	"time"
 
@@ -45,7 +46,8 @@ func main() {
 		logger.Fatal(err)
 	}
 
-	certmetrics.StartMetricsServer(logger, cfg.Metrics.ListenAddress, newCertificateeHealthChecker(vaultClient))
+	healthChecker := newCertificateeHealthChecker(vaultClient, cfg.Certificatee.UpdateInterval)
+	certmetrics.StartMetricsServer(logger, cfg.Metrics.ListenAddress, healthChecker.Check)
 	defer certmetrics.PushMetrics(logger, cfg.Metrics.PushUrl)
 
 	logger.Infof("Configured %d HAProxy endpoint(s)", len(haproxyClients))
@@ -60,25 +62,25 @@ func main() {
 	defer certmetrics.Up.WithLabelValues("certificatee", version, cfg.Hostname, cfg.Environment).Set(0)
 
 	// Initial run
-	if err := maybeUpdateCertificates(logger, cfg, vaultClient, haproxyClients); err != nil {
+	if err := maybeUpdateCertificates(logger, cfg, vaultClient, haproxyClients, healthChecker); err != nil {
 		logger.Error(err)
 	}
 
 	for range ticker.C {
-		if err := maybeUpdateCertificates(logger, cfg, vaultClient, haproxyClients); err != nil {
+		if err := maybeUpdateCertificates(logger, cfg, vaultClient, haproxyClients, healthChecker); err != nil {
 			logger.Error(err)
 		}
 	}
 }
 
-func maybeUpdateCertificates(logger *logrus.Logger, cfg config.Config, vaultClient *vault.VaultClient, haproxyClients []*haproxy.Client) error {
+func maybeUpdateCertificates(logger *logrus.Logger, cfg config.Config, vaultClient *vault.VaultClient, haproxyClients []*haproxy.Client, healthChecker *certificateeHealthChecker) error {
 	var allErrs []error
 
 	for _, haproxyClient := range haproxyClients {
 		endpoint := haproxyClient.Endpoint()
 		logger.Infof("Processing HAProxy endpoint: %s", endpoint)
 
-		if err := processHAProxyEndpoint(logger, cfg, vaultClient, haproxyClient); err != nil {
+		if err := processHAProxyEndpoint(logger, cfg, vaultClient, haproxyClient, healthChecker); err != nil {
 			allErrs = append(allErrs, fmt.Errorf("endpoint %s: %w", endpoint, err))
 			logger.Errorf("Failed to process endpoint %s: %v", endpoint, err)
 		}
@@ -87,17 +89,26 @@ func maybeUpdateCertificates(logger *logrus.Logger, cfg config.Config, vaultClie
 	return errors.Join(allErrs...)
 }
 
-func processHAProxyEndpoint(logger *logrus.Logger, cfg config.Config, vaultClient *vault.VaultClient, haproxyClient *haproxy.Client) error {
+func processHAProxyEndpoint(logger *logrus.Logger, cfg config.Config, vaultClient *vault.VaultClient, haproxyClient *haproxy.Client, healthChecker *certificateeHealthChecker) error {
 	endpoint := haproxyClient.Endpoint()
 
 	certRefs, err := haproxyClient.ListCertificateRefs()
 	if err != nil {
+		if haproxy.IsHTTPStatus(err, http.StatusNotFound) {
+			setEndpointV3Unsupported(endpoint)
+			// Do not cache this state. Endpoints can be upgraded independently,
+			// so every sync run probes the v3 runtime certificate API again.
+			logger.Warnf("[%s] HAProxy Data Plane API does not expose the v3 runtime SSL certificate API; skipping endpoint this run: %v", endpoint, err)
+			return nil
+		}
+
 		setEndpointState(endpoint, 0, 0, 0)
-		return fmt.Errorf("failed to list live certificates: %w", err)
+		return err
 	}
 
 	// Mark endpoint as up and record sync timestamp
 	setEndpointState(endpoint, 1, 1, 0)
+	healthChecker.MarkEndpointSyncSuccess()
 	certmetrics.LastSyncTimestamp.WithLabelValues(endpoint).SetToCurrentTime()
 	certmetrics.CertificatesTotal.WithLabelValues(endpoint).Set(float64(len(certRefs)))
 
@@ -180,7 +191,15 @@ func processHAProxyEndpoint(logger *logrus.Logger, cfg config.Config, vaultClien
 func setEndpointState(endpoint string, reachable, v3Ready, working float64) {
 	certmetrics.HAProxyEndpointUp.WithLabelValues(endpoint, "reachable").Set(reachable)
 	certmetrics.HAProxyEndpointUp.WithLabelValues(endpoint, "v3_ready").Set(v3Ready)
+	certmetrics.HAProxyEndpointUp.WithLabelValues(endpoint, "v3_unsupported").Set(0)
 	certmetrics.HAProxyEndpointUp.WithLabelValues(endpoint, "working").Set(working)
+}
+
+func setEndpointV3Unsupported(endpoint string) {
+	certmetrics.HAProxyEndpointUp.WithLabelValues(endpoint, "reachable").Set(1)
+	certmetrics.HAProxyEndpointUp.WithLabelValues(endpoint, "v3_ready").Set(0)
+	certmetrics.HAProxyEndpointUp.WithLabelValues(endpoint, "v3_unsupported").Set(1)
+	certmetrics.HAProxyEndpointUp.WithLabelValues(endpoint, "working").Set(0)
 }
 
 func shouldUpdateCertificate(domain string, vaultClient *vault.VaultClient, haproxyCert *haproxy.CertificateDetail, renewBeforeDays int) (shouldUpdate bool, reason string, isExpiring bool, err error) {

--- a/cmd/certificatee/main_test.go
+++ b/cmd/certificatee/main_test.go
@@ -3,10 +3,16 @@ package main
 import (
 	"crypto/x509"
 	"math/big"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/sirupsen/logrus"
+	"github.com/vinted/certificator/pkg/certmetrics"
+	"github.com/vinted/certificator/pkg/config"
 	"github.com/vinted/certificator/pkg/haproxy"
 )
 
@@ -76,4 +82,52 @@ func TestShouldUpdateForSerialMismatch(t *testing.T) {
 			t.Fatalf("shouldUpdate=%v reason=%q, want no update", shouldUpdate, reason)
 		}
 	})
+
+	t.Run("ignores leading zero serial padding", func(t *testing.T) {
+		shouldUpdate, reason := shouldUpdateForSerialMismatch(vaultCert, &haproxy.CertificateDetail{Serial: "01:F5:20:2E:0"})
+		if shouldUpdate || reason != "" {
+			t.Fatalf("shouldUpdate=%v reason=%q, want no update", shouldUpdate, reason)
+		}
+	})
+}
+
+func TestProcessHAProxyEndpointSkipsUnsupportedDataPlaneAPI(t *testing.T) {
+	logger := logrus.New()
+	logger.SetLevel(logrus.PanicLevel)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v3/services/haproxy/runtime/ssl_certs" {
+			t.Fatalf("unexpected path %q", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"message":"path /v3/services/haproxy/runtime/ssl_certs was not found"}`))
+	}))
+	defer server.Close()
+
+	haproxyClient, err := haproxy.NewClient(haproxy.ClientConfig{BaseURL: server.URL}, logger)
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+
+	healthChecker := newCertificateeHealthChecker(nil, time.Minute)
+	err = processHAProxyEndpoint(logger, config.Config{}, nil, haproxyClient, healthChecker)
+	if err != nil {
+		t.Fatalf("processHAProxyEndpoint() error = %v, want nil", err)
+	}
+
+	if got := testutil.ToFloat64(certmetrics.HAProxyEndpointUp.WithLabelValues(server.URL, "reachable")); got != 1 {
+		t.Fatalf("reachable metric = %v, want 1", got)
+	}
+	if got := testutil.ToFloat64(certmetrics.HAProxyEndpointUp.WithLabelValues(server.URL, "v3_ready")); got != 0 {
+		t.Fatalf("v3_ready metric = %v, want 0", got)
+	}
+	if got := testutil.ToFloat64(certmetrics.HAProxyEndpointUp.WithLabelValues(server.URL, "v3_unsupported")); got != 1 {
+		t.Fatalf("v3_unsupported metric = %v, want 1", got)
+	}
+	if got := testutil.ToFloat64(certmetrics.HAProxyEndpointUp.WithLabelValues(server.URL, "working")); got != 0 {
+		t.Fatalf("working metric = %v, want 0", got)
+	}
+	if lastSync := healthChecker.lastSync(); !lastSync.IsZero() {
+		t.Fatalf("health last sync = %s, want zero", lastSync)
+	}
 }

--- a/pkg/haproxy/client.go
+++ b/pkg/haproxy/client.go
@@ -46,6 +46,33 @@ type ClientConfig struct {
 	Timeout            time.Duration
 }
 
+// UnexpectedStatusError is returned when the Data Plane API responds with an
+// HTTP status that is not valid for the requested operation.
+type UnexpectedStatusError struct {
+	Operation  string
+	StatusCode int
+	Body       string
+}
+
+func (e *UnexpectedStatusError) Error() string {
+	return fmt.Sprintf("%s: status %d, body: %s", e.Operation, e.StatusCode, e.Body)
+}
+
+// IsHTTPStatus reports whether err wraps an UnexpectedStatusError with the
+// given status code.
+func IsHTTPStatus(err error, statusCode int) bool {
+	var statusErr *UnexpectedStatusError
+	return errors.As(err, &statusErr) && statusErr.StatusCode == statusCode
+}
+
+func unexpectedStatusError(operation string, statusCode int, body []byte) error {
+	return &UnexpectedStatusError{
+		Operation:  operation,
+		StatusCode: statusCode,
+		Body:       string(body),
+	}
+}
+
 // NewClient creates a new HAProxy Data Plane API client
 func NewClient(cfg ClientConfig, logger *logrus.Logger) (*Client, error) {
 	if cfg.BaseURL == "" {
@@ -231,7 +258,7 @@ func (c *Client) ListCertificateRefs() ([]CertificateRef, error) {
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
-		return nil, errors.Errorf("failed to list live certificates: status %d, body: %s", resp.StatusCode, string(body))
+		return nil, unexpectedStatusError("failed to list live certificates", resp.StatusCode, body)
 	}
 
 	var certs []SSLCertificateEntry
@@ -441,7 +468,8 @@ func IsExpiring(certInfo *CertInfo, renewBeforeDays int) bool {
 }
 
 // NormalizeSerial normalizes a certificate serial number for comparison.
-// Removes non-hex characters and converts to uppercase.
+// Removes non-hex characters, converts to uppercase, and strips insignificant
+// leading zeroes.
 func NormalizeSerial(serial string) string {
 	var b strings.Builder
 	b.Grow(len(serial))
@@ -457,7 +485,17 @@ func NormalizeSerial(serial string) string {
 		}
 	}
 
-	return b.String()
+	normalized := b.String()
+	if normalized == "" {
+		return ""
+	}
+
+	trimmed := strings.TrimLeft(normalized, "0")
+	if trimmed == "" {
+		return "0"
+	}
+
+	return trimmed
 }
 
 // logrusLeveledLogger wraps a logrus.Logger to implement retryablehttp.LeveledLogger

--- a/pkg/haproxy/client_test.go
+++ b/pkg/haproxy/client_test.go
@@ -117,6 +117,9 @@ func TestNormalizeSerial(t *testing.T) {
 		{"1f:52:02:e0", "1F5202E0"},
 		{"  1F5202E0  ", "1F5202E0"},
 		{"1F-52-02-E0", "1F5202E0"},
+		{"01F5202E0", "1F5202E0"},
+		{"00:1f:52:02:e0", "1F5202E0"},
+		{"0000", "0"},
 		{"", ""},
 	}
 
@@ -448,6 +451,32 @@ func TestListCertificates(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestListCertificateRefsReturnsStatusError(t *testing.T) {
+	logger := logrus.New()
+	logger.SetLevel(logrus.PanicLevel)
+
+	mock := newMockDataPlaneAPI(t)
+	defer mock.Close()
+
+	mock.SetHandler("GET", "/v3/services/haproxy/runtime/ssl_certs", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"message":"path not found"}`))
+	})
+
+	client, err := NewClient(ClientConfig{BaseURL: mock.URL()}, logger)
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+
+	_, err = client.ListCertificateRefs()
+	if err == nil {
+		t.Fatal("ListCertificateRefs() error = nil, want status error")
+	}
+	if !IsHTTPStatus(err, http.StatusNotFound) {
+		t.Fatalf("IsHTTPStatus(err, 404) = false, err = %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- skip endpoints that do not expose the DPAPI v3 runtime SSL certificate API, report them with certificatee_haproxy_endpoint_up{state="v3_unsupported"}, and re-check every run
- make /health require Vault plus a recent successful DPAPI v3 runtime certificate API probe from at least one endpoint
- normalize serial numbers by stripping insignificant leading zeroes before comparing Vault and live HAProxy metadata

## Tests
- GOCACHE=/tmp/go-build-cache GOMODCACHE=/tmp/go-mod-cache go test ./...
