### PR TITLE
Expose certificatee dataplaneapi version metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Certificatee exposes Prometheus metrics for monitoring:
 
 | Metric | Type | Labels | Description |
 |--------|------|--------|-------------|
-| `certificatee_haproxy_endpoint_up` | Gauge | endpoint, state | Endpoint state. `state="reachable"` and `state="v3_ready"` mean the v3 runtime API is available, `state="v3_unsupported"` means the endpoint did not expose the v3 runtime certificate API on the last run, and `state="working"` means certificatee processed the endpoint without certificate errors |
+| `certificatee_dataplaneapi_version` | Gauge | endpoint, version | Detected HAProxy Data Plane API version for certificatee endpoints. `version` is `v2` or `v3`; the detected version is set to 1 and the other version is set to 0 |
 | `certificatee_certificate_not_after_timestamp_seconds` | Gauge | endpoint, domain | Live certificate expiry reported by the HAProxy Data Plane API runtime endpoint |
 | `certificatee_certificate_metadata_lookup_failures_total` | Counter | endpoint, domain | Per-certificate DPAPI runtime metadata lookups that failed |
 | `certificatee_haproxy_connections_total` | Counter | endpoint, status | Total connection attempts (status: success/failure) |

--- a/cmd/certificatee/main.go
+++ b/cmd/certificatee/main.go
@@ -95,19 +95,19 @@ func processHAProxyEndpoint(logger *logrus.Logger, cfg config.Config, vaultClien
 	certRefs, err := haproxyClient.ListCertificateRefs()
 	if err != nil {
 		if haproxy.IsHTTPStatus(err, http.StatusNotFound) {
-			setEndpointV3Unsupported(endpoint)
+			setDataPlaneAPIVersion(endpoint, "v2")
 			// Do not cache this state. Endpoints can be upgraded independently,
 			// so every sync run probes the v3 runtime certificate API again.
 			logger.Warnf("[%s] HAProxy Data Plane API does not expose the v3 runtime SSL certificate API; skipping endpoint this run: %v", endpoint, err)
 			return nil
 		}
 
-		setEndpointState(endpoint, 0, 0, 0)
+		setDataPlaneAPIVersion(endpoint, "")
 		return err
 	}
 
 	// Mark endpoint as up and record sync timestamp
-	setEndpointState(endpoint, 1, 1, 0)
+	setDataPlaneAPIVersion(endpoint, "v3")
 	healthChecker.MarkEndpointSyncSuccess()
 	certmetrics.LastSyncTimestamp.WithLabelValues(endpoint).SetToCurrentTime()
 	certmetrics.CertificatesTotal.WithLabelValues(endpoint).Set(float64(len(certRefs)))
@@ -179,27 +179,18 @@ func processHAProxyEndpoint(logger *logrus.Logger, cfg config.Config, vaultClien
 
 	// Record expiring certificates count
 	certmetrics.CertificatesExpiring.WithLabelValues(endpoint).Set(float64(expiringCount))
-	if len(errs) == 0 {
-		setEndpointState(endpoint, 1, 1, 1)
-	} else {
-		setEndpointState(endpoint, 1, 1, 0)
-	}
 
 	return errors.Join(errs...)
 }
 
-func setEndpointState(endpoint string, reachable, v3Ready, working float64) {
-	certmetrics.HAProxyEndpointUp.WithLabelValues(endpoint, "reachable").Set(reachable)
-	certmetrics.HAProxyEndpointUp.WithLabelValues(endpoint, "v3_ready").Set(v3Ready)
-	certmetrics.HAProxyEndpointUp.WithLabelValues(endpoint, "v3_unsupported").Set(0)
-	certmetrics.HAProxyEndpointUp.WithLabelValues(endpoint, "working").Set(working)
-}
-
-func setEndpointV3Unsupported(endpoint string) {
-	certmetrics.HAProxyEndpointUp.WithLabelValues(endpoint, "reachable").Set(1)
-	certmetrics.HAProxyEndpointUp.WithLabelValues(endpoint, "v3_ready").Set(0)
-	certmetrics.HAProxyEndpointUp.WithLabelValues(endpoint, "v3_unsupported").Set(1)
-	certmetrics.HAProxyEndpointUp.WithLabelValues(endpoint, "working").Set(0)
+func setDataPlaneAPIVersion(endpoint, version string) {
+	for _, candidate := range []string{"v2", "v3"} {
+		value := 0.0
+		if version == candidate {
+			value = 1
+		}
+		certmetrics.DataPlaneAPIVersion.WithLabelValues(endpoint, candidate).Set(value)
+	}
 }
 
 func shouldUpdateCertificate(domain string, vaultClient *vault.VaultClient, haproxyCert *haproxy.CertificateDetail, renewBeforeDays int) (shouldUpdate bool, reason string, isExpiring bool, err error) {

--- a/cmd/certificatee/main_test.go
+++ b/cmd/certificatee/main_test.go
@@ -115,19 +115,48 @@ func TestProcessHAProxyEndpointSkipsUnsupportedDataPlaneAPI(t *testing.T) {
 		t.Fatalf("processHAProxyEndpoint() error = %v, want nil", err)
 	}
 
-	if got := testutil.ToFloat64(certmetrics.HAProxyEndpointUp.WithLabelValues(server.URL, "reachable")); got != 1 {
-		t.Fatalf("reachable metric = %v, want 1", got)
+	if got := testutil.ToFloat64(certmetrics.DataPlaneAPIVersion.WithLabelValues(server.URL, "v2")); got != 1 {
+		t.Fatalf("dataplaneapi v2 metric = %v, want 1", got)
 	}
-	if got := testutil.ToFloat64(certmetrics.HAProxyEndpointUp.WithLabelValues(server.URL, "v3_ready")); got != 0 {
-		t.Fatalf("v3_ready metric = %v, want 0", got)
-	}
-	if got := testutil.ToFloat64(certmetrics.HAProxyEndpointUp.WithLabelValues(server.URL, "v3_unsupported")); got != 1 {
-		t.Fatalf("v3_unsupported metric = %v, want 1", got)
-	}
-	if got := testutil.ToFloat64(certmetrics.HAProxyEndpointUp.WithLabelValues(server.URL, "working")); got != 0 {
-		t.Fatalf("working metric = %v, want 0", got)
+	if got := testutil.ToFloat64(certmetrics.DataPlaneAPIVersion.WithLabelValues(server.URL, "v3")); got != 0 {
+		t.Fatalf("dataplaneapi v3 metric = %v, want 0", got)
 	}
 	if lastSync := healthChecker.lastSync(); !lastSync.IsZero() {
 		t.Fatalf("health last sync = %s, want zero", lastSync)
+	}
+}
+
+func TestProcessHAProxyEndpointMarksV3ReadyEndpoint(t *testing.T) {
+	logger := logrus.New()
+	logger.SetLevel(logrus.PanicLevel)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v3/services/haproxy/runtime/ssl_certs" {
+			t.Fatalf("unexpected path %q", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	defer server.Close()
+
+	haproxyClient, err := haproxy.NewClient(haproxy.ClientConfig{BaseURL: server.URL}, logger)
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+
+	healthChecker := newCertificateeHealthChecker(nil, time.Minute)
+	err = processHAProxyEndpoint(logger, config.Config{}, nil, haproxyClient, healthChecker)
+	if err != nil {
+		t.Fatalf("processHAProxyEndpoint() error = %v, want nil", err)
+	}
+
+	if got := testutil.ToFloat64(certmetrics.DataPlaneAPIVersion.WithLabelValues(server.URL, "v2")); got != 0 {
+		t.Fatalf("dataplaneapi v2 metric = %v, want 0", got)
+	}
+	if got := testutil.ToFloat64(certmetrics.DataPlaneAPIVersion.WithLabelValues(server.URL, "v3")); got != 1 {
+		t.Fatalf("dataplaneapi v3 metric = %v, want 1", got)
+	}
+	if lastSync := healthChecker.lastSync(); lastSync.IsZero() {
+		t.Fatal("health last sync is zero, want successful sync timestamp")
 	}
 }

--- a/pkg/certmetrics/metrics.go
+++ b/pkg/certmetrics/metrics.go
@@ -66,11 +66,10 @@ var (
 		Help: "Total number of HAProxy Data Plane API per-certificate metadata lookup failures",
 	}, []string{"endpoint", "domain"})
 
-	// HAProxy endpoint health
-	HAProxyEndpointUp = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "certificatee_haproxy_endpoint_up",
-		Help: "Indicates HAProxy endpoint state for certificatee (1 = true, 0 = false)",
-	}, []string{"endpoint", "state"})
+	DataPlaneAPIVersion = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "certificatee_dataplaneapi_version",
+		Help: "Detected HAProxy Data Plane API version for certificatee endpoints (1 = detected version)",
+	}, []string{"endpoint", "version"})
 	LastSyncTimestamp = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "certificatee_last_sync_timestamp_seconds",
 		Help: "Unix timestamp of the last successful sync",


### PR DESCRIPTION
Summary:
- replace certificatee endpoint state rollout reporting with certificatee_dataplaneapi_version{version="v2"|"v3"}
- mark 404 from the v3 runtime certificate endpoint as dataplaneapi v2 and successful probes as v3
- update certificatee tests and metric docs

Tests:
- /usr/local/go/bin/go test ./cmd/certificatee
- /usr/local/go/bin/go test ./...